### PR TITLE
fix(ci): add checkout step to deploy-docs job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
       contents: write
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Download docs artifact
         uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
## Problem

The `deploy-docs` job was failing with:
```
fatal: not in a git directory
Error: There was an error initializing the repository
```

`JamesIves/github-pages-deploy-action` needs to run inside a git repository to push to the `gh-pages` branch. The job only downloaded the artifact but had no `actions/checkout` step, so the runner workspace had no `.git` directory.

## Fix

Add `actions/checkout@v6` as the first step in `deploy-docs` before downloading the artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)