### PR TITLE
fix(demo): remove ES5 browserslist warning & fix Material suffix border

### DIFF
--- a/projects/demo/.browserslistrc
+++ b/projects/demo/.browserslistrc
@@ -5,8 +5,10 @@
 # You can see what browsers were selected by your queries by running:
 #   npx browserslist
 
-> 0.5%
-last 2 versions
+last 2 Chrome versions
+last 2 Firefox versions
+last 2 Edge major versions
+last 2 Safari major versions
+last 2 iOS major versions
 Firefox ESR
 not dead
-not IE 9-11 # For IE 9-11 support, remove 'not'.

--- a/projects/demo/src/styles.scss
+++ b/projects/demo/src/styles.scss
@@ -119,6 +119,11 @@ body {
         box-shadow: 0 0 0 2px rgba(63, 81, 181, 0.15);
       }
     }
+
+    // Keep text suffixes (e.g. ".00") from sitting flush against the outline border
+    .mat-mdc-form-field-text-suffix {
+      padding-right: 8px;
+    }
   }
 
   .model-display {
@@ -232,7 +237,7 @@ body {
   min-height: 48px;
   cursor: text;
 
-  input:not([mat-input]) {
+  input:not(.mat-mdc-input-element) {
     flex: 1;
     min-width: 120px;
     border: none !important;


### PR DESCRIPTION
## What

Two small demo-only fixes, also serving as a live test of the docs-deploy CI/CD pipeline.

### 1. Drop IE from browserslist (removes ES5 build warning)
The build emitted:
> One or more browsers which are configured in the project's Browserslist configuration will be ignored as ES5 output is not supported by the Angular CLI.

The Angular CLI no longer produces ES5 output, so the legacy `not IE 9-11` query only triggered this warning. Replaced the old query set with a modern evergreen-browser list.

### 2. Fix `.00` suffix touching the Material outline border
In the **Angular Material Integration** example the `.00` text suffix sat flush against the outline border. Added right padding to `.mat-mdc-form-field-text-suffix`, and aligned the address-input selector with the modern `.mat-mdc-input-element` class used elsewhere.

## Verification
- `npm run build-docs` completes with **no** browserslist/ES5 warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)