### PR TITLE
fix: select-value-of falsy values + configurable no-match-found (v18.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project follows [Angular version numbers](https://angular.dev/reference
 
 ---
 
+## [18.6.0] — 2026-06-04
+
+### Fixed
+- `select-value-of` now correctly extracts falsy property values (`0`, `null`, `false`, `''`) from the
+  selected object — previously the truthiness check caused the raw item to be emitted instead of the
+  extracted property (fixes #373)
+
+### Added
+- `no-match-found-text=""` (empty string) now fully suppresses the "No Result Found" row — previously
+  the empty string fell through to the default text (fixes #307, #292, #198)
+- `(noMatchFound)` output on both `<ngui-auto-complete>` component and `[ngui-auto-complete]` directive —
+  fires whenever the filtered list is empty and `min-chars` threshold has been met, enabling consumers
+  to render an "Add new…" affordance
+
+---
+
 ## [18.5.0] — 2026-06-03
 
 ### Fixed

--- a/projects/auto-complete/package.json
+++ b/projects/auto-complete/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngui/auto-complete",
-  "version": "18.5.0",
+  "version": "18.6.0",
   "description": "Angular Input Autocomplete",
   "license": "MIT",
   "repository": {

--- a/projects/auto-complete/src/lib/auto-complete.component.html
+++ b/projects/auto-complete/src/lib/auto-complete.component.html
@@ -15,9 +15,9 @@
     <li *ngIf="isLoading && loadingTemplate" class="loading"
         [innerHTML]="loadingTemplate"></li>
     <li *ngIf="isLoading && !loadingTemplate" class="loading">{{ loadingText }}</li>
-    <li *ngIf="minCharsEntered && !isLoading && !filteredList.length"
+    <li *ngIf="minCharsEntered && !isLoading && !filteredList.length && noMatchFoundText !== ''"
         (mousedown)="selectOne('')"
-        class="no-match-found">{{ noMatchFoundText || 'No Result Found' }}
+        class="no-match-found">{{ noMatchFoundText ?? 'No Result Found' }}
     </li>
     <li *ngIf="headerItemTemplate && filteredList.length" class="header-item"
         [innerHTML]="headerItemTemplate"></li>

--- a/projects/auto-complete/src/lib/auto-complete.component.ts
+++ b/projects/auto-complete/src/lib/auto-complete.component.ts
@@ -39,6 +39,7 @@ export class NguiAutoCompleteComponent implements OnInit {
   @Output() public valueSelected = new EventEmitter();
   @Output() public customSelected = new EventEmitter();
   @Output() public textEntered = new EventEmitter();
+  @Output() public noMatchFound = new EventEmitter<void>();
 
   @ViewChild('autoCompleteInput') public autoCompleteInput: ElementRef;
   @ViewChild('autoCompleteContainer') public autoCompleteContainer: ElementRef;
@@ -133,6 +134,9 @@ export class NguiAutoCompleteComponent implements OnInit {
       if (this.maxNumList) {
         this.filteredList = this.filteredList.slice(0, this.maxNumList);
       }
+      if (this.minCharsEntered && !this.filteredList.length) {
+        this.noMatchFound.emit();
+      }
 
     } else {// remote source
       this.isLoading = true;
@@ -150,6 +154,9 @@ export class NguiAutoCompleteComponent implements OnInit {
                 this.filteredList = this.filteredList.slice(0, this.maxNumList);
               }
               this.isLoading = false;
+              if (this.minCharsEntered && !this.filteredList.length) {
+                this.noMatchFound.emit();
+              }
             },
             error: (error) => {
               console.warn(error);
@@ -166,6 +173,9 @@ export class NguiAutoCompleteComponent implements OnInit {
               this.filteredList = this.filteredList.slice(0, this.maxNumList);
             }
             this.isLoading = false;
+            if (this.minCharsEntered && !this.filteredList.length) {
+              this.noMatchFound.emit();
+            }
           },
           error: (error) => {
             console.warn(error);

--- a/projects/auto-complete/src/lib/auto-complete.directive.ts
+++ b/projects/auto-complete/src/lib/auto-complete.directive.ts
@@ -60,6 +60,7 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
   @Output() public ngModelChange = new EventEmitter();
   @Output() public valueChanged = new EventEmitter();
   @Output() public customSelected = new EventEmitter();
+  @Output() public noMatchFound = new EventEmitter<void>();
 
   private componentRef: ComponentRef<NguiAutoCompleteComponent>;
   private wrapperEl: HTMLElement;
@@ -199,6 +200,7 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
     this.dropdownSubs.add(component.valueSelected.subscribe(this.selectNewValue));
     this.dropdownSubs.add(component.textEntered.subscribe(this.enterNewText));
     this.dropdownSubs.add(component.customSelected.subscribe(this.selectCustomValue));
+    this.dropdownSubs.add(component.noMatchFound.subscribe(() => this.noMatchFound.emit()));
 
     this.acDropdownEl = this.componentRef.location.nativeElement;
     this.acDropdownEl.style.display = 'none';
@@ -320,7 +322,7 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
 
     // make return value
     let val = item;
-    if (this.selectValueOf && item[this.selectValueOf]) {
+    if (this.selectValueOf && item !== null && typeof item === 'object') {
       val = item[this.selectValueOf];
     }
     if ((this.parentForm && this.formControlName) || this.extFormControl) {


### PR DESCRIPTION
## Summary

- **Fix #373** — `select-value-of` now correctly extracts falsy property values (`0`, `null`, `false`, `''`) from the selected item. The old `item[this.selectValueOf]` truthiness check caused the raw object to be emitted when the extracted property value was falsy.
- **Fix #307 / #292 / #198** — `no-match-found-text=""` (empty string) now fully suppresses the "No Result Found" row. Previously the `||` fallback treated `""` as falsy and showed the default text anyway.
- **Feat** — Added `(noMatchFound)` `EventEmitter<void>` output on both `<ngui-auto-complete>` (component) and `[ngui-auto-complete]` (directive). Fires whenever the filtered list is empty and the `min-chars` threshold has been met — enables "Add new..." affordance patterns. Works for all three source types (static array, observable function, remote URL).

## Changed files

| File | Change |
|------|--------|
| `auto-complete.directive.ts` | Fix `selectValueOf` type guard; add `(noMatchFound)` `@Output` + subscription forwarding |
| `auto-complete.component.ts` | Add `(noMatchFound)` `@Output`; emit in `reloadList` for all source paths |
| `auto-complete.component.html` | `*ngIf` guards `noMatchFoundText !== ''`; use `??` instead of `||` for default text |
| `package.json` (library) | `18.5.0` -> `18.6.0` |
| `CHANGELOG.md` | v18.6.0 entry |

## Test plan

- [ ] Verify `select-value-of` emits `0` when a source item has `{ id: 0, name: 'Zero' }`
- [ ] Verify `no-match-found-text=""` shows no row when no results are found
- [ ] Verify `(noMatchFound)` fires on the directive when the filtered list is empty
- [ ] Verify `(noMatchFound)` fires on the component (`<ngui-auto-complete>`) when the filtered list is empty
- [ ] `npm run build-lib:prod` and `npm run lint` pass (confirmed locally)

Generated with [Claude Code](https://claude.com/claude-code)