### PR TITLE
docs(demo): add (noMatchFound) + no-match-found-text demo cards and README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ searchFn = (keyword: string): Observable<any> => {
 | `list-formatter` | `string \| Function` | — | Format each dropdown item. String pattern `(key) name` or function `(item) => string` |
 | `value-formatter` | `string \| Function` | — | Format the selected value shown in the input |
 | `blank-option-text` | `string` | — | Adds an empty first option with this label |
-| `no-match-found-text` | `string` | — | Text shown when no results match |
+| `no-match-found-text` | `string` | — | Text shown when no results match. Set to `""` to suppress the row entirely |
 | `loading-text` | `string` | `'Loading'` | Text shown while fetching remote data |
 | `loading-template` | `string` | — | HTML string shown while loading |
 | `header-item-template` | `string` | — | Non-selectable header row above results (HTML string) |
@@ -123,6 +123,7 @@ searchFn = (keyword: string): Observable<any> => {
 | `(ngModelChange)` | selected value | Fires when a list item or custom value is accepted |
 | `(valueChanged)` | selected value | Same as `ngModelChange` |
 | `(customSelected)` | keyword string | Fires when user accepts a value not in the list |
+| `(noMatchFound)` | `void` | Fires when the filtered list is empty and `min-chars` threshold is met — use it to show an "Add new…" affordance |
 
 ### Component Inputs (`<ngui-auto-complete>`)
 
@@ -141,6 +142,7 @@ All directive inputs are supported plus:
 | `(valueSelected)` | selected value | Fires when a list item is selected |
 | `(customSelected)` | keyword string | Fires on custom (non-list) value entry |
 | `(textEntered)` | string | Fires when user enters text |
+| `(noMatchFound)` | `void` | Fires when the filtered list is empty and `min-chars` threshold is met — use it to show an "Add new…" affordance |
 
 ---
 

--- a/projects/demo/src/app/directive-test/directive-test.component.html
+++ b/projects/demo/src/app/directive-test/directive-test.component.html
@@ -303,7 +303,72 @@
     </mat-card-content>
   </mat-card>
 
-  <!-- 11. Exact Accent Match -->
+  <!-- 11. (noMatchFound) output -->
+  <mat-card class="demo-card">
+    <mat-card-header>
+      <mat-card-title>(noMatchFound) Output</mat-card-title>
+      <mat-card-subtitle>
+        Fires whenever the filtered list is empty — use it to show an "Add new…" affordance.
+        Type something not in the list (e.g. <em>xyz</em>).
+      </mat-card-subtitle>
+    </mat-card-header>
+    <mat-card-content>
+      <div class="demo-area">
+        <input ngui-auto-complete
+               id="model11"
+               [(ngModel)]="model11"
+               [source]="arrayOfStrings"
+               [accept-user-input]="true"
+               (noMatchFound)="noMatchVisible11 = true"
+               (ngModelChange)="noMatchVisible11 = false"
+               (customSelected)="noMatchVisible11 = false"
+               placeholder="type something not in the list"/>
+        <div *ngIf="noMatchVisible11" class="no-match-hint">
+          <mat-icon>info_outline</mat-icon>
+          Not in the list —
+          <button mat-button color="primary" (click)="addToList11()">Add "{{ model11 }}"</button>
+        </div>
+      </div>
+      <p class="model-display">selected: <code>{{ json(model11) }}</code></p>
+      <mat-expansion-panel class="code-panel">
+        <mat-expansion-panel-header>
+          <mat-panel-title>View Template</mat-panel-title>
+        </mat-expansion-panel-header>
+        <pre>{{ template11b }}</pre>
+      </mat-expansion-panel>
+    </mat-card-content>
+  </mat-card>
+
+  <!-- 12. Suppress "No Result Found" -->
+  <mat-card class="demo-card">
+    <mat-card-header>
+      <mat-card-title>Suppress "No Result Found"</mat-card-title>
+      <mat-card-subtitle>
+        Set <code>no-match-found-text=""</code> to hide the row entirely when nothing matches.
+        Compare with the HTTP Source demo above which shows the message.
+        Type something that won't match (e.g. <em>xyz</em>).
+      </mat-card-subtitle>
+    </mat-card-header>
+    <mat-card-content>
+      <div class="demo-area">
+        <input ngui-auto-complete
+               id="model12"
+               [(ngModel)]="model12"
+               [source]="arrayOfStrings"
+               no-match-found-text=""
+               placeholder="type something not in the list"/>
+      </div>
+      <p class="model-display">selected: <code>{{ json(model12) }}</code></p>
+      <mat-expansion-panel class="code-panel">
+        <mat-expansion-panel-header>
+          <mat-panel-title>View Template</mat-panel-title>
+        </mat-expansion-panel-header>
+        <pre>{{ template12 }}</pre>
+      </mat-expansion-panel>
+    </mat-card-content>
+  </mat-card>
+
+  <!-- 13. Exact Accent Match -->
   <mat-card class="demo-card">
     <mat-card-header>
       <mat-card-title>Accent-Sensitive Matching</mat-card-title>

--- a/projects/demo/src/app/directive-test/directive-test.component.scss
+++ b/projects/demo/src/app/directive-test/directive-test.component.scss
@@ -10,3 +10,19 @@ input:not([mat-input]) {
   max-height: 120px;
   overflow-y: auto;
 }
+
+.no-match-hint {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 6px;
+  font-size: 13px;
+  color: #666;
+
+  mat-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+    color: #888;
+  }
+}

--- a/projects/demo/src/app/directive-test/directive-test.component.ts
+++ b/projects/demo/src/app/directive-test/directive-test.component.ts
@@ -56,6 +56,9 @@ export class DirectiveTestComponent {
   public model8 = '';
   public model9 = '';
   public model10 = '';
+  public model11 = '';
+  public model12 = '';
+  public noMatchVisible11 = false;
   public myModel;
 
   template1 = `
@@ -192,8 +195,40 @@ export class DirectiveTestComponent {
     </div>
   `;
 
+  template11b = `
+  <input ngui-auto-complete
+         [(ngModel)]="model11"
+         [source]="arrayOfStrings"
+         [accept-user-input]="true"
+         (noMatchFound)="noMatchVisible11 = true"
+         (ngModelChange)="noMatchVisible11 = false"
+         (customSelected)="noMatchVisible11 = false"
+         placeholder="type something not in the list" />
+  <div *ngIf="noMatchVisible11" class="no-match-hint">
+    <mat-icon>info_outline</mat-icon>
+    Not in the list —
+    <button mat-button color="primary" (click)="addToList11()">
+      Add "{{ model11 }}"
+    </button>
+  </div>
+  `;
+
+  template12 = `
+  <input ngui-auto-complete
+         [(ngModel)]="model12"
+         [source]="arrayOfStrings"
+         no-match-found-text=""
+         placeholder="type something not in the list" />
+  `;
 
   constructor(public appSvc: AppService) {
+  }
+
+  public addToList11() {
+    if (this.model11 && !this.arrayOfStrings.includes(this.model11)) {
+      this.arrayOfStrings = [...this.arrayOfStrings, this.model11];
+    }
+    this.noMatchVisible11 = false;
   }
 
   public customCallback(text) {


### PR DESCRIPTION
## Summary

Follow-up to #476 — adds demo cards and README docs for the two features shipped in v18.6.0.

### Demo (directive-test)

- **Card 11 — `(noMatchFound)` output**: Type something not in the list (e.g. `xyz`). An inline "Add" hint appears below the input with a button that appends the typed value to the source array. Demonstrates that `(noMatchFound)` fires when the filtered list is empty, enabling "Add new…" patterns.
- **Card 12 — Suppress "No Result Found"**: Uses `no-match-found-text=""` — the row is completely hidden when nothing matches. Contrasts with the HTTP Source card above which shows the message explicitly.

### README

- `(noMatchFound)` added to the **Directive Outputs** table
- `(noMatchFound)` added to the **Component Outputs** table
- `no-match-found-text` description updated: *Set to `""` to suppress the row entirely*

## Test plan

- [ ] `npm run build-docs` passes (confirmed locally)
- [ ] `npm run lint` passes (confirmed locally)
- [ ] Type `xyz` in Card 11 → hint appears; click "Add" → value joins the list
- [ ] Type `xyz` in Card 12 → no "No Result Found" row shown at all
- [ ] README outputs tables render correctly on GitHub

Generated with [Claude Code](https://claude.com/claude-code)