### PR TITLE
fix(demo): suppress built-in no-match row in (noMatchFound) demo card

### DIFF
--- a/projects/demo/src/app/directive-test/directive-test.component.html
+++ b/projects/demo/src/app/directive-test/directive-test.component.html
@@ -319,6 +319,7 @@
                [(ngModel)]="model11"
                [source]="arrayOfStrings"
                [accept-user-input]="true"
+               no-match-found-text=""
                (noMatchFound)="noMatchVisible11 = true"
                (ngModelChange)="noMatchVisible11 = false"
                (customSelected)="noMatchVisible11 = false"

--- a/projects/demo/src/app/directive-test/directive-test.component.ts
+++ b/projects/demo/src/app/directive-test/directive-test.component.ts
@@ -200,6 +200,7 @@ export class DirectiveTestComponent {
          [(ngModel)]="model11"
          [source]="arrayOfStrings"
          [accept-user-input]="true"
+         no-match-found-text=""
          (noMatchFound)="noMatchVisible11 = true"
          (ngModelChange)="noMatchVisible11 = false"
          (customSelected)="noMatchVisible11 = false"


### PR DESCRIPTION
The dropdown's 'No Result Found' \<li>\ row was visible at the same time as the custom hint div, causing a visual overlap.

Fix: add \
o-match-found-text="\ to the demo input — this is exactly the pattern users should follow: suppress the built-in row and replace it with their own UI driven by \(noMatchFound)\.

Generated with [Claude Code](https://claude.com/claude-code)