### PR TITLE
test(e2e): fix stale cypress smoke spec for current demo

### DIFF
--- a/projects/demo/cypress/e2e/spec.cy.ts
+++ b/projects/demo/cypress/e2e/spec.cy.ts
@@ -1,18 +1,25 @@
-describe('Smock Tests', () => {
+describe('Smoke Tests', () => {
   it('Tabs and children containers', () => {
     cy.visit('/');
 
+    // two navigation tabs: Directive and Component
     cy.get('.mat-mdc-tab-links').find('a').its('length').should('eq', 2);
 
-    cy.get('app-directive-test').should('not.exist');
+    // root redirects to /directive-test, so that view is rendered by default
+    cy.get('app-directive-test').should('exist');
     cy.get('app-component-test').should('not.exist');
+    // one mat-card per directive demo
+    cy.get('app-directive-test').find('mat-card').its('length').should('eq', 13);
 
-    cy.get('.mat-mdc-tab-links').find('a').contains('Directive').click();
-
-    cy.get('app-directive-test').find('fieldset').its('length').should('eq', 11);
-
+    // switch to the Component tab
     cy.get('.mat-mdc-tab-links').find('a').contains('Component').click();
+    cy.get('app-component-test').should('exist');
+    cy.get('app-directive-test').should('not.exist');
+    cy.get('app-component-test').find('mat-card').its('length').should('eq', 2);
 
-    cy.get('app-component-test').find('fieldset').its('length').should('eq', 2);
+    // switch back to the Directive tab
+    cy.get('.mat-mdc-tab-links').find('a').contains('Directive').click();
+    cy.get('app-directive-test').should('exist');
+    cy.get('app-component-test').should('not.exist');
   });
 });


### PR DESCRIPTION
## Problem

The Cypress smoke spec (`spec.cy.ts`) fails when run locally:

```
AssertionError: Timed out retrying after 4000ms: Expected <app-directive-test>
not to exist in the DOM, but it was continuously found.
```

The spec was written against an old version of the demo and never caught in CI (CI runs lint + build, not Cypress). Two stale assumptions:

1. It expected the **root route to render no child component** — but `''` redirects to `directive-test` (`app-routing.module.ts`), so `app-directive-test` is always present on load.
2. It counted **`<fieldset>`** elements — the demo was migrated to Angular Material `mat-card`, so there are no `<fieldset>`s anymore.

## Fix

Rewrite the assertions against the current demo:
- two nav tabs (Directive / Component)
- the root view renders `app-directive-test` (not `app-component-test`)
- switching tabs routes in the correct child and removes the other
- per-view `mat-card` counts (directive: 13, component: 2)

Also fixed the `Smock` → `Smoke` describe typo.

## Validation
- ✅ `npx eslint` on the spec passes (flat config + eslint-plugin-cypress 6)
- ⚠️ Full `npm run cypress:run` should be confirmed locally — the e2e dev server could not start in my sandbox environment (worker-thread limit), so I verified the fix by static analysis of the routing + current demo DOM rather than a live run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)