### PR TITLE
docs(changelog): document tooling changes in the 19.0.0 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,20 @@ and this project follows [Angular version numbers](https://angular.dev/reference
 - Migrated the library template to Angular's built-in control flow syntax (`@if` / `@for` in place of
   `*ngIf` / `*ngFor`).
 
+### Internal (development tooling only — no impact on consumers)
+- Migrated ESLint from `.eslintrc.json` to flat config (`eslint.config.js`); upgraded ESLint 8 → 9 and
+  switched to the unified `angular-eslint` and `typescript-eslint` packages.
+- Bumped dev dependencies to the newest versions compatible with Angular 19: `cypress` 13 → 15,
+  `@cypress/schematic` 2 → 4.3, `eslint-plugin-cypress` 3 → 6, `jasmine-core` + `@types/jasmine` 5 → 6,
+  `@types/node` 22 → 24, `karma-jasmine-html-reporter` 2.1 → 2.2 (reduces `npm audit` from 52 to 9).
+- Added unit specs for the library component and service, and replaced the stale Angular CLI boilerplate
+  demo specs with working `TestBed` setups.
+
 ### Notes
 - The library remains NgModule-based in this release; the standalone migration is planned for the
   Angular 20 release.
+- ESLint 10, `@cypress/schematic` 5, and the standalone migration are deferred to the Angular 20 release
+  (they require Angular 20 / angular-eslint 20).
 
 ---
 


### PR DESCRIPTION
## Why

The `19.0.0` CHANGELOG entry was written before the dev-tooling work landed in PR #479, and only listed the framework upgrade + control flow migration. This completes it so the entry is accurate before the `@ngui/auto-complete@19.0.0` npm publish.

## What

Adds an **Internal (development tooling only — no impact on consumers)** section to the `19.0.0` entry:
- ESLint `.eslintrc.json` → flat config, ESLint 8 → 9, unified `angular-eslint` / `typescript-eslint`
- Dev-dep bumps compatible with Angular 19 (`cypress` 13→15, `@cypress/schematic` 2→4.3, `eslint-plugin-cypress` 3→6, `jasmine` 5→6, `@types/node` 22→24, `karma-jasmine-html-reporter` 2.1→2.2; `npm audit` 52 → 9)
- New library specs + reworked demo specs

Plus a note clarifying that ESLint 10, `@cypress/schematic` 5, and the standalone migration are deferred to the Angular 20 release.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)