### PR TITLE
feat: add open-direction input to control dropdown side (#386)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project follows [Angular version numbers](https://angular.dev/reference
   customize dropdown rows and the header row, as a typed alternative to the string-based `list-formatter`
   / `header-item-template`. The item template receives the item as `$implicit` and the row `index`; the
   string formatters remain supported and the templates take precedence when provided (fixes #357).
+- `open-direction` input (`auto` | `up` | `down`) on the directive and component to control whether the
+  dropdown opens above or below the input. `up`/`down` force the direction; `auto` (default) keeps the
+  previous behaviour of opening above only when the input is near the bottom of the viewport (fixes #386).
 
 ### Changed
 - **Upgraded to Angular 20** (`@angular/*` 20.3.x, `@angular/material` + `@angular/cdk` 20.2.x).

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ works on both the component and the directive:
 | `ignore-accents` | `boolean` | `true` | Treat accented characters as their base characters during matching |
 | `autocomplete` | `boolean` | `false` | Set `autocomplete="off"` on the input (`false` = off) |
 | `is-rtl` | `boolean` | `false` | Right-to-left dropdown positioning |
+| `open-direction` | `'auto' \| 'up' \| 'down'` | `'auto'` | Force the dropdown above (`up`) or below (`down`) the input. `auto` opens below unless the input is near the bottom of the viewport |
 | `z-index` | `string` | `'1'` | CSS z-index of the dropdown |
 
 ### Directive Outputs
@@ -172,6 +173,9 @@ All directive inputs are supported plus:
 | `show-input-tag` | `boolean` | `true` | Render an `<input>` inside the component |
 | `show-dropdown-on-init` | `boolean` | `false` | Open dropdown immediately when component appears |
 | `placeholder` | `string` | — | Placeholder text for the internal input |
+
+> **Note:** for the standalone component, `open-direction="up"` renders the dropdown above the input via
+> CSS; `auto`/`down` keep it below. The viewport-aware `auto` flip applies to the directive usage.
 
 ### Component Outputs
 

--- a/projects/auto-complete/src/lib/auto-complete.component.html
+++ b/projects/auto-complete/src/lib/auto-complete.component.html
@@ -14,7 +14,7 @@
 
   <!-- dropdown that user can select -->
   @if (dropdownVisible) {
-    <ul [class.empty]="emptyList">
+    <ul [class.empty]="emptyList" [class.dropup]="openDirection === 'up'">
       @if (isLoading && loadingTemplate) {
         <li class="loading"
         [innerHTML]="loadingTemplate"></li>

--- a/projects/auto-complete/src/lib/auto-complete.component.scss
+++ b/projects/auto-complete/src/lib/auto-complete.component.scss
@@ -9,6 +9,7 @@
 
 .ngui-auto-complete {
   background-color: transparent;
+  position: relative;
 }
 
 .ngui-auto-complete > input {
@@ -33,6 +34,12 @@
 
 .ngui-auto-complete > ul.empty {
   display: none;
+}
+
+.ngui-auto-complete > ul.dropup {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
 }
 
 .ngui-auto-complete > ul li {

--- a/projects/auto-complete/src/lib/auto-complete.component.spec.ts
+++ b/projects/auto-complete/src/lib/auto-complete.component.spec.ts
@@ -35,6 +35,22 @@ describe('NguiAutoCompleteComponent', () => {
     expect(component.showInputTag).toBe(true);
     expect(component.acceptUserInput).toBe(true);
   });
+
+  it('should default open-direction to "auto" and not mark the dropdown as dropup', () => {
+    component.dropdownVisible = true;
+    fixture.detectChanges();
+    const dropdown: HTMLElement = fixture.nativeElement.querySelector('ul');
+    expect(component.openDirection).toBe('auto');
+    expect(dropdown.classList.contains('dropup')).toBe(false);
+  });
+
+  it('should add the "dropup" class when open-direction is "up"', () => {
+    component.openDirection = 'up';
+    component.dropdownVisible = true;
+    fixture.detectChanges();
+    const dropdown: HTMLElement = fixture.nativeElement.querySelector('ul');
+    expect(dropdown.classList.contains('dropup')).toBe(true);
+  });
 });
 
 @Component({

--- a/projects/auto-complete/src/lib/auto-complete.component.ts
+++ b/projects/auto-complete/src/lib/auto-complete.component.ts
@@ -44,6 +44,9 @@ export class NguiAutoCompleteComponent implements OnInit {
   // and the row index as `index`.
   @Input() public itemTemplate: TemplateRef<{ $implicit: any; index: number }>;
   @Input() public headerTemplate: TemplateRef<void>;
+  // When used as a standalone component (not via the directive), `up` renders the
+  // dropdown above the input; `down`/`auto` keep it below.
+  @Input('open-direction') public openDirection: 'auto' | 'up' | 'down' = 'auto';
 
   @Output() public valueSelected = new EventEmitter();
   @Output() public customSelected = new EventEmitter();

--- a/projects/auto-complete/src/lib/auto-complete.directive.ts
+++ b/projects/auto-complete/src/lib/auto-complete.directive.ts
@@ -47,6 +47,9 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
   @Input('formControl') public extFormControl: FormControl;
   @Input('z-index') public zIndex = '1';
   @Input('is-rtl') public isRtl = false;
+  // 'down' / 'up' force the dropdown below / above the input; 'auto' (default) opens
+  // below unless the input sits near the bottom of the viewport.
+  @Input('open-direction') public openDirection: 'auto' | 'up' | 'down' = 'auto';
 
   @Output() public ngModelChange = new EventEmitter();
   @Output() public valueChanged = new EventEmitter();
@@ -255,12 +258,8 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
 
   public styleAutoCompleteDropdown = () => {
     if (this.componentRef) {
-      const component = this.componentRef.instance;
-
       /* setting width/height auto complete */
-      const thisElBCR = this.el.getBoundingClientRect();
       const thisInputElBCR = this.inputEl.getBoundingClientRect();
-      const closeToBottom = thisInputElBCR.bottom + 100 > window.innerHeight;
       const directionOfStyle = this.isRtl ? 'right' : 'left';
 
       this.acDropdownEl.style.width = thisInputElBCR.width + 'px';
@@ -269,13 +268,30 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
       this.acDropdownEl.style[directionOfStyle] = '0';
       this.acDropdownEl.style.display = 'inline-block';
 
-      if (closeToBottom) {
+      // Reset any previous vertical anchor so re-styling is deterministic.
+      this.acDropdownEl.style.top = '';
+      this.acDropdownEl.style.bottom = '';
+
+      if (this.shouldOpenUp(thisInputElBCR)) {
         this.acDropdownEl.style.bottom = `${thisInputElBCR.height}px`;
       } else {
         this.acDropdownEl.style.top = `${thisInputElBCR.height}px`;
       }
     }
   };
+
+  // Resolve the vertical opening direction honouring the `open-direction` input.
+  // 'auto' keeps the historic heuristic: open above only when the input is within
+  // ~100px of the viewport bottom.
+  private shouldOpenUp(inputBCR: DOMRect): boolean {
+    if (this.openDirection === 'up') {
+      return true;
+    }
+    if (this.openDirection === 'down') {
+      return false;
+    }
+    return inputBCR.bottom + 100 > window.innerHeight;
+  }
 
   public setToStringFunction(item: any): any {
     if (item && typeof item === 'object') {

--- a/projects/demo/src/app/directive-test/directive-test.component.html
+++ b/projects/demo/src/app/directive-test/directive-test.component.html
@@ -409,18 +409,19 @@
     <mat-card-header>
       <mat-card-title>Dropdown Open Direction</mat-card-title>
       <mat-card-subtitle>
-        Force the dropdown with <code>open-direction</code>. The picker is, ironically, another autocomplete.
+        Force the dropdown above or below the input with <code>open-direction</code>.
+        Pick a direction, then focus the input below.
       </mat-card-subtitle>
     </mat-card-header>
     <mat-card-content>
       <div class="demo-area">
-        <label class="direction-picker">direction:
-          <input ngui-auto-complete
-            [(ngModel)]="openDir"
-            [source]="directionOptions"
-            [accept-user-input]="false"
-            [auto-select-first-item]="true"
-            placeholder="auto | up | down"/>
+        <label class="direction-picker">
+          direction:
+          <select [(ngModel)]="openDir">
+            <option value="auto">auto</option>
+            <option value="up">up</option>
+            <option value="down">down</option>
+          </select>
         </label>
         <div ngui-auto-complete
           [source]="arrayOfStrings"

--- a/projects/demo/src/app/directive-test/directive-test.component.html
+++ b/projects/demo/src/app/directive-test/directive-test.component.html
@@ -404,4 +404,42 @@
     </mat-card-content>
   </mat-card>
 
+  <!-- Open direction (up / down / auto) -->
+  <mat-card class="demo-card">
+    <mat-card-header>
+      <mat-card-title>Dropdown Open Direction</mat-card-title>
+      <mat-card-subtitle>
+        Force the dropdown with <code>open-direction</code>. The picker is, ironically, another autocomplete.
+      </mat-card-subtitle>
+    </mat-card-header>
+    <mat-card-content>
+      <div class="demo-area">
+        <label class="direction-picker">direction:
+          <input ngui-auto-complete
+            [(ngModel)]="openDir"
+            [source]="directionOptions"
+            [accept-user-input]="false"
+            [auto-select-first-item]="true"
+            placeholder="auto | up | down"/>
+        </label>
+        <div ngui-auto-complete
+          [source]="arrayOfStrings"
+          [open-direction]="openDir"
+          [accept-user-input]="true"
+          [select-on-blur]="true"
+          (ngModelChange)="myCallback1($event)"
+          (customSelected)="customCallback($event)">
+          <input id="model13" [ngModel]="model13" placeholder="opens {{ openDir }}"/>
+        </div>
+      </div>
+      <p class="model-display">direction: <code>{{ openDir }}</code> · selected: <code>{{ json(model13) }}</code></p>
+      <mat-expansion-panel class="code-panel">
+        <mat-expansion-panel-header>
+          <mat-panel-title>View Template</mat-panel-title>
+        </mat-expansion-panel-header>
+        <pre>{{ template13 }}</pre>
+      </mat-expansion-panel>
+    </mat-card-content>
+  </mat-card>
+
 </div>

--- a/projects/demo/src/app/directive-test/directive-test.component.scss
+++ b/projects/demo/src/app/directive-test/directive-test.component.scss
@@ -11,6 +11,19 @@ input:not([mat-input]) {
   overflow-y: auto;
 }
 
+.direction-picker {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 16px;
+  font-size: 13px;
+  color: #666;
+
+  select {
+    padding: 4px 8px;
+  }
+}
+
 .no-match-hint {
   display: flex;
   align-items: center;

--- a/projects/demo/src/app/directive-test/directive-test.component.ts
+++ b/projects/demo/src/app/directive-test/directive-test.component.ts
@@ -70,8 +70,12 @@ export class DirectiveTestComponent {
   public model10 = '';
   public model11 = '';
   public model12 = '';
+  public model13 = '';
   public noMatchVisible11 = false;
   public myModel;
+
+  public openDir = 'auto';
+  public directionOptions = ['auto', 'up', 'down'];
 
   template1 = `
   <div ngui-auto-complete
@@ -234,6 +238,22 @@ export class DirectiveTestComponent {
          [source]="arrayOfStrings"
          no-match-found-text=""
          placeholder="type something not in the list" />
+  `;
+
+  template13 = `
+  <!-- the direction picker is, ironically, another autocomplete -->
+  <input ngui-auto-complete
+         [(ngModel)]="openDir"
+         [source]="directionOptions"
+         [accept-user-input]="false"
+         [auto-select-first-item]="true"
+         placeholder="auto | up | down" />
+
+  <input ngui-auto-complete
+         [(ngModel)]="model13"
+         [source]="arrayOfStrings"
+         [open-direction]="openDir"
+         placeholder="opens {{ openDir }}" />
   `;
 
   public addToList11() {

--- a/projects/demo/src/app/directive-test/directive-test.component.ts
+++ b/projects/demo/src/app/directive-test/directive-test.component.ts
@@ -75,7 +75,6 @@ export class DirectiveTestComponent {
   public myModel;
 
   public openDir = 'auto';
-  public directionOptions = ['auto', 'up', 'down'];
 
   template1 = `
   <div ngui-auto-complete
@@ -241,19 +240,19 @@ export class DirectiveTestComponent {
   `;
 
   template13 = `
-  <!-- the direction picker is, ironically, another autocomplete -->
-  <input ngui-auto-complete
-         [(ngModel)]="openDir"
-         [source]="directionOptions"
-         [accept-user-input]="false"
-         [auto-select-first-item]="true"
-         placeholder="auto | up | down" />
+  <label>direction:
+    <select [(ngModel)]="openDir">
+      <option value="auto">auto</option>
+      <option value="up">up</option>
+      <option value="down">down</option>
+    </select>
+  </label>
 
-  <input ngui-auto-complete
-         [(ngModel)]="model13"
-         [source]="arrayOfStrings"
-         [open-direction]="openDir"
-         placeholder="opens {{ openDir }}" />
+  <div ngui-auto-complete
+       [source]="arrayOfStrings"
+       [open-direction]="openDir">
+    <input [ngModel]="model13" placeholder="opens {{ openDir }}" />
+  </div>
   `;
 
   public addToList11() {


### PR DESCRIPTION
## #386 — open the dropdown above the input

Adds an `open-direction` input so consumers can control whether the dropdown opens above or below the input.

### Why
The directive already auto-flipped upward when the input sat near the viewport bottom, but the heuristic was a fixed `+100px` guess, there was **no way to force a direction**, and the **standalone component had no flip at all**. (Fixes #386.)

### What
- **`open-direction`** (`'auto' | 'up' | 'down'`, default `'auto'`) on both the directive and the component.
  - `up` / `down` force the side.
  - `auto` keeps the previous behaviour (open above only when the input is near the bottom of the viewport).
- **Directive:** `styleAutoCompleteDropdown` now resets `top`/`bottom` on each call so re-styling is deterministic, and drops two unused locals.
- **Component (standalone usage):** `open-direction="up"` renders the dropdown above via a `dropup` CSS modifier (`position: absolute; bottom: 100%`) — it had no positioning of its own before.
- Component specs for the default (`auto` → no `dropup`) and `up` (→ `dropup`) cases.
- README API tables + CHANGELOG updated.

### Note / scope
True pixel-perfect "auto" (measuring the rendered dropdown height to decide) needs post-render measurement because `styleAutoCompleteDropdown` runs before `dropdownVisible` flips the list into the DOM — out of scope here. This PR delivers reliable explicit control + keeps the existing `auto` heuristic with no regression.

### Validation
`lint`, `build-lib:prod`, and library unit tests (8/8, +2 new) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)