### PR TITLE
feat: ng-template customization for dropdown rows (#357)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project follows [Angular version numbers](https://angular.dev/reference
   (the directive now matches `[ngui-auto-complete]` only). Update any templates using the bare
   `auto-complete` attribute: `<input auto-complete …>` → `<input ngui-auto-complete …>`.
 
+### Added
+- `itemTemplate` and `headerTemplate` inputs (Angular `ng-template`s) on the component and directive to
+  customize dropdown rows and the header row, as a typed alternative to the string-based `list-formatter`
+  / `header-item-template`. The item template receives the item as `$implicit` and the row `index`; the
+  string formatters remain supported and the templates take precedence when provided (fixes #357).
+
 ### Changed
 - **Upgraded to Angular 20** (`@angular/*` 20.3.x, `@angular/material` + `@angular/cdk` 20.2.x).
   Install `@ngui/auto-complete@20` for Angular 20 projects.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,22 @@ searchFn = (keyword: string): Observable<any> => {
 };
 ```
 
+### Custom dropdown templates
+
+Instead of the string-based `list-formatter` / `header-item-template`, you can pass Angular
+`ng-template`s. `itemTemplate` receives the item as `$implicit` and the row index as `index`; it
+works on both the component and the directive:
+
+```html
+<input ngui-auto-complete [(ngModel)]="myValue" [source]="myArray"
+  [itemTemplate]="row" [headerTemplate]="head" />
+
+<ng-template #head>Suggestions</ng-template>
+<ng-template #row let-item let-i="index">
+  <strong>{{ i + 1 }}.</strong> {{ item.name }} — <em>{{ item.country }}</em>
+</ng-template>
+```
+
 ---
 
 ## API Reference
@@ -117,6 +133,8 @@ searchFn = (keyword: string): Observable<any> => {
 | `display-property-name` | `string` | `value` | Object key to display in the input after selection |
 | `select-value-of` | `string` | — | Return this key's value on selection instead of the full object |
 | `list-formatter` | `string \| Function` | — | Format each dropdown item. String pattern `(key) name` or function `(item) => string` |
+| `itemTemplate` | `TemplateRef` | — | `ng-template` for each dropdown row (context: `$implicit` = item, `index` = row index). Takes precedence over `list-formatter` |
+| `headerTemplate` | `TemplateRef` | — | `ng-template` for the non-selectable header row. Takes precedence over `header-item-template` |
 | `value-formatter` | `string \| Function` | — | Format the selected value shown in the input |
 | `blank-option-text` | `string` | — | Adds an empty first option with this label |
 | `no-match-found-text` | `string` | — | Text shown when no results match. Set to `""` to suppress the row entirely |

--- a/projects/auto-complete/src/lib/auto-complete.component.html
+++ b/projects/auto-complete/src/lib/auto-complete.component.html
@@ -28,7 +28,11 @@
           class="no-match-found">{{ noMatchFoundText ?? 'No Result Found' }}
         </li>
       }
-      @if (headerItemTemplate && filteredList.length) {
+      @if (headerTemplate && filteredList.length) {
+        <li class="header-item">
+          <ng-container [ngTemplateOutlet]="headerTemplate"></ng-container>
+        </li>
+      } @else if (headerItemTemplate && filteredList.length) {
         <li class="header-item"
         [innerHTML]="headerItemTemplate"></li>
       }
@@ -39,11 +43,20 @@
         </li>
       }
       @for (item of filteredList; track trackByIndex(i, item); let i = $index) {
-        <li class="item"
-          (mousedown)="selectOne(item)"
-          [ngClass]="{selected: i === itemIndex}"
-          [innerHtml]="autoComplete.getFormattedListItem(item)">
-        </li>
+        @if (itemTemplate) {
+          <li class="item"
+            (mousedown)="selectOne(item)"
+            [ngClass]="{selected: i === itemIndex}">
+            <ng-container [ngTemplateOutlet]="itemTemplate"
+              [ngTemplateOutletContext]="{ $implicit: item, index: i }"></ng-container>
+          </li>
+        } @else {
+          <li class="item"
+            (mousedown)="selectOne(item)"
+            [ngClass]="{selected: i === itemIndex}"
+            [innerHtml]="autoComplete.getFormattedListItem(item)">
+          </li>
+        }
       }
     </ul>
   }

--- a/projects/auto-complete/src/lib/auto-complete.component.spec.ts
+++ b/projects/auto-complete/src/lib/auto-complete.component.spec.ts
@@ -1,4 +1,6 @@
+import { Component, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 
 import { NguiAutoCompleteComponent } from './auto-complete.component';
 import { NguiAutoCompleteModule } from './auto-complete.module';
@@ -32,5 +34,38 @@ describe('NguiAutoCompleteComponent', () => {
   it('should default to showing the input tag and accepting user input', () => {
     expect(component.showInputTag).toBe(true);
     expect(component.acceptUserInput).toBe(true);
+  });
+});
+
+@Component({
+  imports: [NguiAutoCompleteComponent],
+  template: `
+    <ngui-auto-complete [source]="source" [itemTemplate]="tpl"></ngui-auto-complete>
+    <ng-template #tpl let-item let-i="index">custom:{{ item }}:{{ i }}</ng-template>
+  `,
+})
+class TemplateHostComponent {
+  source = ['Alpha', 'Beta'];
+  @ViewChild(NguiAutoCompleteComponent) autoComplete: NguiAutoCompleteComponent;
+}
+
+describe('NguiAutoCompleteComponent itemTemplate', () => {
+  it('should render each row with the provided item template', () => {
+    const fixture = TestBed.createComponent(TemplateHostComponent);
+    fixture.detectChanges();
+
+    const ac = fixture.componentInstance.autoComplete;
+    ac.filteredList = ['Alpha', 'Beta'];
+    ac.dropdownVisible = true;
+    fixture.detectChanges();
+
+    const rows = fixture.debugElement
+      .query(By.directive(NguiAutoCompleteComponent))
+      .nativeElement.querySelectorAll('li.item');
+    expect(rows.length).toBe(2);
+    expect(rows[0].textContent.trim()).toBe('custom:Alpha:0');
+    expect(rows[1].textContent.trim()).toBe('custom:Beta:1');
+
+    fixture.destroy();
   });
 });

--- a/projects/auto-complete/src/lib/auto-complete.component.ts
+++ b/projects/auto-complete/src/lib/auto-complete.component.ts
@@ -1,8 +1,8 @@
-import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild, ViewEncapsulation, inject } from '@angular/core';
+import { Component, ElementRef, EventEmitter, Input, OnInit, Output, TemplateRef, ViewChild, ViewEncapsulation, inject } from '@angular/core';
 import { NguiAutoCompleteService } from './auto-complete.service';
 import { Observable } from 'rxjs';
 import { FormsModule } from '@angular/forms';
-import { NgClass } from '@angular/common';
+import { NgClass, NgTemplateOutlet } from '@angular/common';
 
 @Component({
     selector: 'ngui-auto-complete',
@@ -10,7 +10,7 @@ import { NgClass } from '@angular/common';
     styleUrls: ['./auto-complete.component.scss'],
     encapsulation: ViewEncapsulation.None,
     providers: [NguiAutoCompleteService],
-    imports: [FormsModule, NgClass]
+    imports: [FormsModule, NgClass, NgTemplateOutlet]
 })
 export class NguiAutoCompleteComponent implements OnInit {
   autoComplete = inject(NguiAutoCompleteService);
@@ -39,6 +39,11 @@ export class NguiAutoCompleteComponent implements OnInit {
   @Input('re-focus-after-select') public reFocusAfterSelect = true;
   @Input('header-item-template') public headerItemTemplate = null;
   @Input('ignore-accents') public ignoreAccents = true;
+  // Angular template alternatives to the string `list-formatter` / `header-item-template`.
+  // When provided they take precedence; the item template receives the item as `$implicit`
+  // and the row index as `index`.
+  @Input() public itemTemplate: TemplateRef<{ $implicit: any; index: number }>;
+  @Input() public headerTemplate: TemplateRef<void>;
 
   @Output() public valueSelected = new EventEmitter();
   @Output() public customSelected = new EventEmitter();

--- a/projects/auto-complete/src/lib/auto-complete.directive.ts
+++ b/projects/auto-complete/src/lib/auto-complete.directive.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, ComponentRef, Directive, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges, ViewContainerRef, inject } from '@angular/core';
+import { AfterViewInit, ComponentRef, Directive, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges, TemplateRef, ViewContainerRef, inject } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { AbstractControl, ControlContainer, FormControl, FormGroup, FormGroupName } from '@angular/forms';
 import { NguiAutoCompleteComponent } from './auto-complete.component';
@@ -35,6 +35,10 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
   @Input('re-focus-after-select') public reFocusAfterSelect = true;
   @Input('header-item-template') public headerItemTemplate = null;
   @Input('ignore-accents') public ignoreAccents = true;
+  // Angular template alternatives to the string `list-formatter` / `header-item-template`,
+  // forwarded to the dropdown component (they take precedence when provided).
+  @Input() public itemTemplate: TemplateRef<{ $implicit: any; index: number }>;
+  @Input() public headerTemplate: TemplateRef<void>;
 
   @Input() public ngModel: string;
   @Input('formControlName') public formControlName: string;
@@ -179,6 +183,8 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
     component.matchFormatted = this.matchFormatted;
     component.autoSelectFirstItem = this.autoSelectFirstItem;
     component.headerItemTemplate = this.headerItemTemplate;
+    component.itemTemplate = this.itemTemplate;
+    component.headerTemplate = this.headerTemplate;
     component.ignoreAccents = this.ignoreAccents;
 
     this.dropdownSubs.unsubscribe();

--- a/projects/demo/src/app/component-test/component-test.component.html
+++ b/projects/demo/src/app/component-test/component-test.component.html
@@ -81,4 +81,46 @@
     </mat-card-content>
   </mat-card>
 
+  <!-- Custom item / header templates -->
+  <mat-card class="demo-card">
+    <mat-card-header>
+      <mat-card-title>Custom Item Template</mat-card-title>
+      <mat-card-subtitle>
+        Render each row with an <code>ng-template</code> via <code>[itemTemplate]</code>, plus a header
+        row via <code>[headerTemplate]</code>.
+      </mat-card-subtitle>
+    </mat-card-header>
+    <mat-card-content>
+      <div class="demo-area">
+        <input
+          [(ngModel)]="tplModel"
+          (focus)="showTpl = true"
+          (blur)="showTpl = false"
+          placeholder="focus to browse people"/>
+        @if (showTpl) {
+          <ngui-auto-complete
+            [show-dropdown-on-init]="true"
+            [show-input-tag]="false"
+            [source]="people"
+            display-property-name="name"
+            (valueSelected)="tplModel = $event"
+            [headerTemplate]="peopleHead"
+            [itemTemplate]="peopleRow">
+          </ngui-auto-complete>
+        }
+        <ng-template #peopleHead>Pioneers of computing</ng-template>
+        <ng-template #peopleRow let-person let-i="index">
+          <strong>{{ i + 1 }}. {{ person.name }}</strong> — {{ person.role }} ({{ person.year }})
+        </ng-template>
+      </div>
+      <p class="model-display">selected: <code>{{ tplModel?.name }}</code></p>
+      <mat-expansion-panel class="code-panel">
+        <mat-expansion-panel-header>
+          <mat-panel-title>View Template</mat-panel-title>
+        </mat-expansion-panel-header>
+        <pre>{{ templateStr3 }}</pre>
+      </mat-expansion-panel>
+    </mat-card-content>
+  </mat-card>
+
 </div>

--- a/projects/demo/src/app/component-test/component-test.component.html
+++ b/projects/demo/src/app/component-test/component-test.component.html
@@ -93,9 +93,10 @@
     <mat-card-content>
       <div class="demo-area">
         <input
-          [(ngModel)]="tplModel"
+          [ngModel]="tplModel?.name"
           (focus)="showTpl = true"
           (blur)="showTpl = false"
+          readonly
           placeholder="focus to browse people"/>
         @if (showTpl) {
           <ngui-auto-complete

--- a/projects/demo/src/app/component-test/component-test.component.ts
+++ b/projects/demo/src/app/component-test/component-test.component.ts
@@ -23,6 +23,14 @@ export class ComponentTestComponent {
 
   myModel;
   showMe;
+  tplModel;
+  showTpl = false;
+  public people: any[] = [
+    {name: 'Ada Lovelace', role: 'Mathematician', year: 1815},
+    {name: 'Alan Turing', role: 'Computer Scientist', year: 1912},
+    {name: 'Grace Hopper', role: 'Computer Scientist', year: 1906},
+    {name: 'Katherine Johnson', role: 'Mathematician', year: 1918}
+  ];
 
   templateStr1 = `<div class="addr-input-wrapper" (click)="showAutocomplete = true">
   @for (addr of addrs; track addr; let i = $index) {
@@ -61,6 +69,26 @@ export class ComponentTestComponent {
     [source]="[1, 2, 3, 4, 5]">
   </ngui-auto-complete>
 }`;
+
+  templateStr3 = `
+<input [(ngModel)]="tplModel"
+       (focus)="showTpl = true" (blur)="showTpl = false"
+       placeholder="focus to browse people"/>
+@if (showTpl) {
+  <ngui-auto-complete
+    [show-dropdown-on-init]="true"
+    [show-input-tag]="false"
+    [source]="people"
+    display-property-name="name"
+    (valueSelected)="tplModel = $event"
+    [headerTemplate]="peopleHead"
+    [itemTemplate]="peopleRow">
+  </ngui-auto-complete>
+}
+<ng-template #peopleHead>Pioneers of computing</ng-template>
+<ng-template #peopleRow let-person let-i="index">
+  <strong>{{ i + 1 }}. {{ person.name }}</strong> — {{ person.role }} ({{ person.year }})
+</ng-template>`;
 
   public addToAddress(addr: any): void {
     this.addrs.push(addr);

--- a/projects/demo/src/app/component-test/component-test.component.ts
+++ b/projects/demo/src/app/component-test/component-test.component.ts
@@ -71,9 +71,9 @@ export class ComponentTestComponent {
 }`;
 
   templateStr3 = `
-<input [(ngModel)]="tplModel"
+<input [ngModel]="tplModel?.name"
        (focus)="showTpl = true" (blur)="showTpl = false"
-       placeholder="focus to browse people"/>
+       readonly placeholder="focus to browse people"/>
 @if (showTpl) {
   <ngui-auto-complete
     [show-dropdown-on-init]="true"


### PR DESCRIPTION
## #357 — use `ng-template` to customise dropdown elements

Adds typed Angular-template customization of the dropdown, as an alternative to the string-based `list-formatter` / `header-item-template`.

### What
- **`itemTemplate`** — `ng-template` for each row, rendered via `ngTemplateOutlet`. Context: `$implicit` = the item, `index` = the row index.
- **`headerTemplate`** — `ng-template` for the non-selectable header row.
- Both are available on the **component** and forwarded by the **directive** to the dynamically-created dropdown component.
- The existing **string formatters remain fully supported**; the templates simply take precedence when provided (non-breaking).

```html
<input ngui-auto-complete [(ngModel)]="myValue" [source]="myArray"
  [itemTemplate]="row" [headerTemplate]="head" />

<ng-template #head>Suggestions</ng-template>
<ng-template #row let-item let-i="index">
  <strong>{{ i + 1 }}.</strong> {{ item.name }} — <em>{{ item.country }}</em>
</ng-template>
```

### Tests / docs
- New host-component spec renders rows through a custom template and asserts the output.
- README usage section + API rows + CHANGELOG updated.

### Validation
`lint`, `build-lib:prod`, and library unit tests (7/7, +1 new) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)