### PR TITLE
fix(issue-template): link to README #usage anchor

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,7 +14,7 @@ body:
       options:
         - label: I am running the latest version of `@ngui/auto-complete`
           required: true
-        - label: I checked the [README](https://github.com/ng2-ui/auto-complete#readme) and found no answer
+        - label: I checked the [README](https://github.com/ng2-ui/auto-complete#usage) and found no answer
           required: true
         - label: I searched existing issues and this has not already been reported
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Usage question
-    url: https://github.com/ng2-ui/auto-complete#readme
+    url: https://github.com/ng2-ui/auto-complete#usage
     about: For "how do I…" questions, please check the README first.


### PR DESCRIPTION
Follow-up to #487. The issue-form README links used `#readme` (which scrolls to the top of the rendered README); `#usage` lands on the **Usage** section, which is the intended target.

Updated in `bug_report.yml` and `config.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)