### PR TITLE
build(deps): bump rxjs 7.8.2 and tslib 2.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,8 @@
         "@angular/platform-browser": "^20.3.24",
         "@angular/platform-browser-dynamic": "^20.3.24",
         "@angular/router": "^20.3.24",
-        "rxjs": "~7.8.1",
-        "tslib": "^2.7.0",
+        "rxjs": "~7.8.2",
+        "tslib": "^2.8.1",
         "zone.js": "~0.15.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "@angular/platform-browser": "^20.3.24",
     "@angular/platform-browser-dynamic": "^20.3.24",
     "@angular/router": "^20.3.24",
-    "rxjs": "~7.8.1",
-    "tslib": "^2.7.0",
+    "rxjs": "~7.8.2",
+    "tslib": "^2.8.1",
     "zone.js": "~0.15.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Safe dependency bumps (Angular 20 compatible)

- **rxjs** `~7.8.1` → `~7.8.2` (patch)
- **tslib** `^2.7.0` → `^2.8.1` (minor)

Both are backward-compatible and within Angular 20''s allowed ranges. The library''s own `tslib ^2.7.0` floor in `projects/auto-complete/package.json` is intentionally left as-is — the caret already permits 2.8.1, and keeping the floor low avoids tightening the requirement on consumers.

### Deferred (not Angular-20-safe)
From the same outdated/Dependabot list, these require newer Angular and are left for the corresponding upgrade:
- `angular-eslint@21` + `eslint@10` + `@eslint/js@10` — angular-eslint 21 peers `@angular/cli >=21 <22` (→ Angular 21).
- `ng-packagr@22` — peers `@angular/compiler-cli ^22` + `typescript >=6 <6.1` (→ Angular 22 + TS 6).
- The open uuid / webpack-dev-server Dependabot alerts are dev-only transitive deps of the Angular build tooling (not in the published package) and clear with those upgrades.

### Validation
`lint` ✅ · `build-lib:prod` ✅ · `build-docs` ✅ · unit tests (lib 9/9 + demo 5/5) ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)