### PR TITLE
refactor(lib): signal inputs/outputs + attribute transforms (Phase A, non-breaking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ and this project follows [Angular version numbers](https://angular.dev/reference
 ### Changed
 - **Upgraded to Angular 21** (`@angular/*` 21.2.x, `@angular/material` + `@angular/cdk` 21.2.x).
   Install `@ngui/auto-complete@21` for Angular 21 projects.
+- **Signal-based inputs/outputs.** All `@Input()`s are now signal `input()`s and all `@Output()`s are
+  `output()`s on both the component and directive (the component's `@ViewChild`s became `viewChild()`
+  queries). Template bindings are unchanged — every input keeps its existing name/alias (e.g.
+  `min-chars`, `list-formatter`). The only consumer-visible effect is for code that reaches into a
+  component/directive **instance** programmatically: those input properties are now read-only signals
+  (call them, e.g. `cmp.minChars()`), not plain fields.
+- **Typed attribute coercion.** Numeric inputs (`min-chars`, `max-num-list`, `z-index`) now use
+  `numberAttribute` and boolean inputs use `booleanAttribute`, so string-attribute forms (`min-chars="2"`)
+  and bound forms (`[min-chars]="2"`) are both correctly typed.
+- Bumped the library's own `tslib` dependency floor to `^2.8.1`.
 
 ### Internal (development tooling only — no impact on consumers)
 - `ng update` to Angular 21: `@angular/cli` + `@angular-devkit/build-angular` 21.2.x,
@@ -28,6 +38,8 @@ and this project follows [Angular version numbers](https://angular.dev/reference
   zone-based change detection).
 - **ESLint 10.** Bumped `eslint` and `@eslint/js` to 10 and `angular-eslint` to 21.4.0 (its ESLint peer
   now allows `^10`), unblocking the upgrade deferred in 19.0.0 / 20.0.0.
+- The directive now forwards inputs to the dynamically created dropdown via `ComponentRef.setInput()`
+  (required now that the component's inputs are read-only signals).
 
 ---
 

--- a/projects/auto-complete/package.json
+++ b/projects/auto-complete/package.json
@@ -19,7 +19,7 @@
     "select"
   ],
   "dependencies": {
-    "tslib": "^2.7.0"
+    "tslib": "^2.8.1"
   },
   "peerDependencies": {
     "@angular/common": "^21.0.0",

--- a/projects/auto-complete/src/lib/auto-complete.component.html
+++ b/projects/auto-complete/src/lib/auto-complete.component.html
@@ -1,11 +1,11 @@
 <div #autoCompleteContainer class="ngui-auto-complete">
 	<!-- keyword input -->
-	@if (showInputTag) {
+	@if (showInputTag()) {
 		<input
 			#autoCompleteInput
 			class="keyword"
-			[attr.autocomplete]="autocomplete ? 'null' : 'off'"
-			placeholder="{{ placeholder }}"
+			[attr.autocomplete]="autocomplete() ? 'null' : 'off'"
+			placeholder="{{ placeholder() }}"
 			(focus)="showDropdownList($event)"
 			(blur)="blurHandler($event)"
 			(keydown)="inputElKeyHandler($event)"
@@ -15,30 +15,30 @@
 
 	<!-- dropdown that user can select -->
 	@if (dropdownVisible) {
-		<ul [class.empty]="emptyList" [class.dropup]="openDirection === 'up'">
-			@if (isLoading && loadingTemplate) {
-				<li class="loading" [innerHTML]="loadingTemplate"></li>
+		<ul [class.empty]="emptyList" [class.dropup]="openDirection() === 'up'">
+			@if (isLoading && loadingTemplate()) {
+				<li class="loading" [innerHTML]="loadingTemplate()"></li>
 			}
-			@if (isLoading && !loadingTemplate) {
-				<li class="loading">{{ loadingText }}</li>
+			@if (isLoading && !loadingTemplate()) {
+				<li class="loading">{{ loadingText() }}</li>
 			}
-			@if (minCharsEntered && !isLoading && !filteredList.length && noMatchFoundText !== '') {
-				<li (mousedown)="selectOne('')" class="no-match-found">{{ noMatchFoundText ?? 'No Result Found' }}</li>
+			@if (minCharsEntered && !isLoading && !filteredList.length && noMatchFoundText() !== '') {
+				<li (mousedown)="selectOne('')" class="no-match-found">{{ noMatchFoundText() ?? 'No Result Found' }}</li>
 			}
-			@if (headerTemplate && filteredList.length) {
+			@if (headerTemplate() && filteredList.length) {
 				<li class="header-item">
-					<ng-container [ngTemplateOutlet]="headerTemplate"></ng-container>
+					<ng-container [ngTemplateOutlet]="headerTemplate()"></ng-container>
 				</li>
-			} @else if (headerItemTemplate && filteredList.length) {
-				<li class="header-item" [innerHTML]="headerItemTemplate"></li>
+			} @else if (headerItemTemplate() && filteredList.length) {
+				<li class="header-item" [innerHTML]="headerItemTemplate()"></li>
 			}
-			@if (blankOptionText && filteredList.length) {
-				<li (mousedown)="selectOne('')" class="blank-item">{{ blankOptionText }}</li>
+			@if (blankOptionText() && filteredList.length) {
+				<li (mousedown)="selectOne('')" class="blank-item">{{ blankOptionText() }}</li>
 			}
 			@for (item of filteredList; track trackByIndex(i, item); let i = $index) {
-				@if (itemTemplate) {
+				@if (itemTemplate()) {
 					<li class="item" (mousedown)="selectOne(item)" [ngClass]="{ selected: i === itemIndex }">
-						<ng-container [ngTemplateOutlet]="itemTemplate" [ngTemplateOutletContext]="{ $implicit: item, index: i }"></ng-container>
+						<ng-container [ngTemplateOutlet]="itemTemplate()" [ngTemplateOutletContext]="{ $implicit: item, index: i }"></ng-container>
 					</li>
 				} @else {
 					<li

--- a/projects/auto-complete/src/lib/auto-complete.component.spec.ts
+++ b/projects/auto-complete/src/lib/auto-complete.component.spec.ts
@@ -18,7 +18,7 @@ describe('NguiAutoCompleteComponent', () => {
 		// Provide a local array source so the focus-triggered dropdown reload (scheduled
 		// from ngOnInit) resolves against local data instead of calling getRemoteData,
 		// which throws on a non-string source.
-		component.source = ['Item 1', 'Item 2'];
+		fixture.componentRef.setInput('source', ['Item 1', 'Item 2']);
 		fixture.detectChanges();
 	});
 
@@ -31,20 +31,20 @@ describe('NguiAutoCompleteComponent', () => {
 	});
 
 	it('should default to showing the input tag and accepting user input', () => {
-		expect(component.showInputTag).toBe(true);
-		expect(component.acceptUserInput).toBe(true);
+		expect(component.showInputTag()).toBe(true);
+		expect(component.acceptUserInput()).toBe(true);
 	});
 
 	it('should default open-direction to "auto" and not mark the dropdown as dropup', () => {
 		component.dropdownVisible = true;
 		fixture.detectChanges();
 		const dropdown: HTMLElement = fixture.nativeElement.querySelector('ul');
-		expect(component.openDirection).toBe('auto');
+		expect(component.openDirection()).toBe('auto');
 		expect(dropdown.classList.contains('dropup')).toBe(false);
 	});
 
 	it('should add the "dropup" class when open-direction is "up"', () => {
-		component.openDirection = 'up';
+		fixture.componentRef.setInput('open-direction', 'up');
 		component.dropdownVisible = true;
 		fixture.detectChanges();
 		const dropdown: HTMLElement = fixture.nativeElement.querySelector('ul');

--- a/projects/auto-complete/src/lib/auto-complete.component.ts
+++ b/projects/auto-complete/src/lib/auto-complete.component.ts
@@ -1,14 +1,15 @@
 import {
+	booleanAttribute,
 	Component,
 	ElementRef,
-	EventEmitter,
-	Input,
+	numberAttribute,
 	OnInit,
-	Output,
 	TemplateRef,
-	ViewChild,
 	ViewEncapsulation,
 	inject,
+	input,
+	output,
+	viewChild,
 } from '@angular/core';
 import { NguiAutoCompleteService } from './auto-complete.service';
 import { Observable } from 'rxjs';
@@ -29,43 +30,46 @@ export class NguiAutoCompleteComponent implements OnInit {
 	/**
 	 * public input properties
 	 */
-	@Input('autocomplete') public autocomplete = false;
-	@Input('list-formatter') public listFormatter: (arg: any) => string;
-	@Input('source') public source: any;
-	@Input('path-to-data') public pathToData: string;
-	@Input('min-chars') public minChars = 0;
-	@Input('placeholder') public placeholder: string;
-	@Input('blank-option-text') public blankOptionText: string;
-	@Input('no-match-found-text') public noMatchFoundText: string;
-	@Input('accept-user-input') public acceptUserInput = true;
-	@Input('loading-text') public loadingText = 'Loading';
-	@Input('loading-template') public loadingTemplate = null;
-	@Input('max-num-list') public maxNumList: number;
-	@Input('show-input-tag') public showInputTag = true;
-	@Input('show-dropdown-on-init') public showDropdownOnInit = false;
-	@Input('tab-to-select') public tabToSelect = true;
-	@Input('match-formatted') public matchFormatted = false;
-	@Input('auto-select-first-item') public autoSelectFirstItem = false;
-	@Input('select-on-blur') public selectOnBlur = false;
-	@Input('re-focus-after-select') public reFocusAfterSelect = true;
-	@Input('header-item-template') public headerItemTemplate = null;
-	@Input('ignore-accents') public ignoreAccents = true;
+	public autocomplete = input(false, { transform: booleanAttribute });
+	public listFormatter = input<((arg: any) => string) | undefined>(undefined, { alias: 'list-formatter' });
+	public source = input<any>();
+	public pathToData = input<string | undefined>(undefined, { alias: 'path-to-data' });
+	public minChars = input(0, { alias: 'min-chars', transform: numberAttribute });
+	public placeholder = input<string | undefined>();
+	public blankOptionText = input<string | undefined>(undefined, { alias: 'blank-option-text' });
+	public noMatchFoundText = input<string | undefined>(undefined, { alias: 'no-match-found-text' });
+	public acceptUserInput = input(true, { alias: 'accept-user-input', transform: booleanAttribute });
+	public loadingText = input('Loading', { alias: 'loading-text' });
+	public loadingTemplate = input<string | null>(null, { alias: 'loading-template' });
+	public maxNumList = input(undefined, {
+		alias: 'max-num-list',
+		transform: (value: string | number | undefined) => (value == null ? undefined : numberAttribute(value)),
+	});
+	public showInputTag = input(true, { alias: 'show-input-tag', transform: booleanAttribute });
+	public showDropdownOnInit = input(false, { alias: 'show-dropdown-on-init', transform: booleanAttribute });
+	public tabToSelect = input(true, { alias: 'tab-to-select', transform: booleanAttribute });
+	public matchFormatted = input(false, { alias: 'match-formatted', transform: booleanAttribute });
+	public autoSelectFirstItem = input(false, { alias: 'auto-select-first-item', transform: booleanAttribute });
+	public selectOnBlur = input(false, { alias: 'select-on-blur', transform: booleanAttribute });
+	public reFocusAfterSelect = input(true, { alias: 're-focus-after-select', transform: booleanAttribute });
+	public headerItemTemplate = input<string | null>(null, { alias: 'header-item-template' });
+	public ignoreAccents = input(true, { alias: 'ignore-accents', transform: booleanAttribute });
 	// Angular template alternatives to the string `list-formatter` / `header-item-template`.
 	// When provided they take precedence; the item template receives the item as `$implicit`
 	// and the row index as `index`.
-	@Input() public itemTemplate: TemplateRef<{ $implicit: any; index: number }>;
-	@Input() public headerTemplate: TemplateRef<void>;
+	public itemTemplate = input<TemplateRef<{ $implicit: any; index: number }> | null>(null);
+	public headerTemplate = input<TemplateRef<void> | null>(null);
 	// When used as a standalone component (not via the directive), `up` renders the
 	// dropdown above the input; `down`/`auto` keep it below.
-	@Input('open-direction') public openDirection: 'auto' | 'up' | 'down' = 'auto';
+	public openDirection = input<'auto' | 'up' | 'down'>('auto', { alias: 'open-direction' });
 
-	@Output() public valueSelected = new EventEmitter();
-	@Output() public customSelected = new EventEmitter();
-	@Output() public textEntered = new EventEmitter();
-	@Output() public noMatchFound = new EventEmitter<void>();
+	public valueSelected = output<any>();
+	public customSelected = output<any>();
+	public textEntered = output<any>();
+	public noMatchFound = output<void>();
 
-	@ViewChild('autoCompleteInput') public autoCompleteInput: ElementRef;
-	@ViewChild('autoCompleteContainer') public autoCompleteContainer: ElementRef;
+	public autoCompleteInput = viewChild<ElementRef>('autoCompleteInput');
+	public autoCompleteContainer = viewChild<ElementRef>('autoCompleteContainer');
 
 	public dropdownVisible = false;
 	public isLoading = false;
@@ -100,24 +104,25 @@ export class NguiAutoCompleteComponent implements OnInit {
 	 * user enters into input el, shows list to select, then select one
 	 */
 	ngOnInit(): void {
-		this.autoComplete.source = this.source;
-		this.autoComplete.pathToData = this.pathToData;
-		this.autoComplete.listFormatter = this.listFormatter;
-		if (this.autoSelectFirstItem) {
+		this.autoComplete.source = this.source();
+		this.autoComplete.pathToData = this.pathToData();
+		this.autoComplete.listFormatter = this.listFormatter();
+		if (this.autoSelectFirstItem()) {
 			this.itemIndex = 0;
 		}
 		setTimeout(() => {
-			if (this.autoCompleteInput && this.reFocusAfterSelect) {
-				this.autoCompleteInput.nativeElement.focus();
+			const input = this.autoCompleteInput();
+			if (input && this.reFocusAfterSelect()) {
+				input.nativeElement.focus();
 			}
-			if (this.showDropdownOnInit) {
+			if (this.showDropdownOnInit()) {
 				this.showDropdownList({ target: { value: '' } });
 			}
 		});
 	}
 
 	public isSrcArr(): boolean {
-		return Array.isArray(this.source);
+		return Array.isArray(this.source());
 	}
 
 	public reloadListInDelay = (evt: any): void => {
@@ -145,19 +150,22 @@ export class NguiAutoCompleteComponent implements OnInit {
 
 	public reloadList(keyword: string): void {
 		this.filteredList = [];
-		if (keyword.length < (this.minChars || 0)) {
+		if (keyword.length < (this.minChars() || 0)) {
 			this.minCharsEntered = false;
 			return;
 		} else {
 			this.minCharsEntered = true;
 		}
 
+		const maxNumList = this.maxNumList();
+		const source = this.source();
+
 		if (this.isSrcArr()) {
 			// local source
 			this.isLoading = false;
-			this.filteredList = this.autoComplete.filter(this.source, keyword, this.matchFormatted, this.ignoreAccents);
-			if (this.maxNumList) {
-				this.filteredList = this.filteredList.slice(0, this.maxNumList);
+			this.filteredList = this.autoComplete.filter(source, keyword, this.matchFormatted(), this.ignoreAccents());
+			if (maxNumList) {
+				this.filteredList = this.filteredList.slice(0, maxNumList);
 			}
 			if (this.minCharsEntered && !this.filteredList.length) {
 				this.noMatchFound.emit();
@@ -166,17 +174,17 @@ export class NguiAutoCompleteComponent implements OnInit {
 			// remote source
 			this.isLoading = true;
 
-			if (typeof this.source === 'function') {
+			if (typeof source === 'function') {
 				// custom function that returns observable
-				(this.source(keyword) as Observable<any>).subscribe({
+				(source(keyword) as Observable<any>).subscribe({
 					next: (resp) => {
-						if (this.pathToData) {
-							const paths = this.pathToData.split('.');
+						if (this.pathToData()) {
+							const paths = this.pathToData().split('.');
 							paths.forEach((prop) => (resp = resp[prop]));
 						}
 						this.filteredList = resp;
-						if (this.maxNumList) {
-							this.filteredList = this.filteredList.slice(0, this.maxNumList);
+						if (maxNumList) {
+							this.filteredList = this.filteredList.slice(0, maxNumList);
 						}
 						this.isLoading = false;
 						if (this.minCharsEntered && !this.filteredList.length) {
@@ -193,8 +201,8 @@ export class NguiAutoCompleteComponent implements OnInit {
 				this.autoComplete.getRemoteData(keyword).subscribe({
 					next: (resp) => {
 						this.filteredList = resp ? resp : [];
-						if (this.maxNumList) {
-							this.filteredList = this.filteredList.slice(0, this.maxNumList);
+						if (maxNumList) {
+							this.filteredList = this.filteredList.slice(0, maxNumList);
 						}
 						this.isLoading = false;
 						if (this.minCharsEntered && !this.filteredList.length) {
@@ -223,7 +231,7 @@ export class NguiAutoCompleteComponent implements OnInit {
 	}
 
 	public blurHandler(evt: any) {
-		if (this.selectOnBlur) {
+		if (this.selectOnBlur()) {
 			this.selectOne(this.filteredList[this.itemIndex]);
 		}
 
@@ -233,7 +241,7 @@ export class NguiAutoCompleteComponent implements OnInit {
 	public inputElKeyHandler = (evt: any) => {
 		const totalNumItem = this.filteredList.length;
 
-		if (!this.selectOnEnter && this.autoSelectFirstItem && 0 !== totalNumItem) {
+		if (!this.selectOnEnter && this.autoSelectFirstItem() && 0 !== totalNumItem) {
 			this.selectOnEnter = true;
 		}
 
@@ -272,7 +280,7 @@ export class NguiAutoCompleteComponent implements OnInit {
 				break;
 
 			case 9: // TAB, choose if tab-to-select is enabled
-				if (this.tabToSelect) {
+				if (this.tabToSelect()) {
 					this.selectOne(this.filteredList[this.itemIndex]);
 				}
 				break;
@@ -280,7 +288,7 @@ export class NguiAutoCompleteComponent implements OnInit {
 	};
 
 	public scrollToView(index) {
-		const container = this.autoCompleteContainer.nativeElement;
+		const container = this.autoCompleteContainer().nativeElement;
 		const ul = container.querySelector('ul');
 		const li = ul.querySelector('li'); // just sample the first li to get height
 		const liHeight = li.offsetHeight;

--- a/projects/auto-complete/src/lib/auto-complete.component.ts
+++ b/projects/auto-complete/src/lib/auto-complete.component.ts
@@ -33,18 +33,18 @@ export class NguiAutoCompleteComponent implements OnInit {
 	public autocomplete = input(false, { transform: booleanAttribute });
 	public listFormatter = input<((arg: any) => string) | undefined>(undefined, { alias: 'list-formatter' });
 	public source = input<any>();
-	public pathToData = input<string | undefined>(undefined, { alias: 'path-to-data' });
+	public pathToData = input('', { alias: 'path-to-data' });
 	public minChars = input(0, { alias: 'min-chars', transform: numberAttribute });
-	public placeholder = input<string | undefined>();
-	public blankOptionText = input<string | undefined>(undefined, { alias: 'blank-option-text' });
+	public placeholder = input('');
+	public blankOptionText = input('', { alias: 'blank-option-text' });
+	// Empty string and "unset" mean different things here: '' suppresses the no-match row,
+	// `undefined` shows the default text — so this input stays optional rather than defaulting.
 	public noMatchFoundText = input<string | undefined>(undefined, { alias: 'no-match-found-text' });
 	public acceptUserInput = input(true, { alias: 'accept-user-input', transform: booleanAttribute });
 	public loadingText = input('Loading', { alias: 'loading-text' });
 	public loadingTemplate = input<string | null>(null, { alias: 'loading-template' });
-	public maxNumList = input(undefined, {
-		alias: 'max-num-list',
-		transform: (value: string | number | undefined) => (value == null ? undefined : numberAttribute(value)),
-	});
+	// 0 means "no limit" (the `if (maxNumList())` guard treats 0 as falsy).
+	public maxNumList = input(0, { alias: 'max-num-list', transform: numberAttribute });
 	public showInputTag = input(true, { alias: 'show-input-tag', transform: booleanAttribute });
 	public showDropdownOnInit = input(false, { alias: 'show-dropdown-on-init', transform: booleanAttribute });
 	public tabToSelect = input(true, { alias: 'tab-to-select', transform: booleanAttribute });

--- a/projects/auto-complete/src/lib/auto-complete.directive.ts
+++ b/projects/auto-complete/src/lib/auto-complete.directive.ts
@@ -28,23 +28,23 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
 	private parentForm = inject(ControlContainer, { optional: true, host: true, skipSelf: true });
 
 	public autocomplete = input(false, { transform: booleanAttribute });
-	public autoCompletePlaceholder = input<string | undefined>(undefined, { alias: 'auto-complete-placeholder' });
+	public autoCompletePlaceholder = input('', { alias: 'auto-complete-placeholder' });
 	public source = input<any>();
-	public pathToData = input<string | undefined>(undefined, { alias: 'path-to-data' });
+	public pathToData = input('', { alias: 'path-to-data' });
 	public minChars = input(0, { alias: 'min-chars', transform: numberAttribute });
-	public displayPropertyName = input<string | undefined>(undefined, { alias: 'display-property-name' });
+	public displayPropertyName = input('', { alias: 'display-property-name' });
 	public acceptUserInput = input(true, { alias: 'accept-user-input', transform: booleanAttribute });
-	public maxNumList = input(undefined, {
-		alias: 'max-num-list',
-		transform: (value: string | number | undefined) => (value == null ? undefined : numberAttribute(value)),
-	});
-	public selectValueOf = input<string | undefined>(undefined, { alias: 'select-value-of' });
+	// 0 means "no limit" (the `if (maxNumList())` guard treats 0 as falsy).
+	public maxNumList = input(0, { alias: 'max-num-list', transform: numberAttribute });
+	public selectValueOf = input('', { alias: 'select-value-of' });
 	public loadingTemplate = input<string | null>(null, { alias: 'loading-template' });
 	public listFormatter = input<((arg: any) => string) | string | undefined>(undefined, { alias: 'list-formatter' });
 	public loadingText = input('Loading', { alias: 'loading-text' });
-	public blankOptionText = input<string | undefined>(undefined, { alias: 'blank-option-text' });
+	public blankOptionText = input('', { alias: 'blank-option-text' });
+	// Empty string and "unset" mean different things here: '' suppresses the no-match row,
+	// `undefined` shows the default text — so this input stays optional rather than defaulting.
 	public noMatchFoundText = input<string | undefined>(undefined, { alias: 'no-match-found-text' });
-	public valueFormatter = input<any>(undefined, { alias: 'value-formatter' });
+	public valueFormatter = input<string | ((item: any) => string) | undefined>(undefined, { alias: 'value-formatter' });
 	public tabToSelect = input(true, { alias: 'tab-to-select', transform: booleanAttribute });
 	public selectOnBlur = input(false, { alias: 'select-on-blur', transform: booleanAttribute });
 	public matchFormatted = input(false, { alias: 'match-formatted', transform: booleanAttribute });

--- a/projects/auto-complete/src/lib/auto-complete.directive.ts
+++ b/projects/auto-complete/src/lib/auto-complete.directive.ts
@@ -1,17 +1,19 @@
 import {
 	AfterViewInit,
+	booleanAttribute,
 	ComponentRef,
 	Directive,
-	EventEmitter,
 	Input,
+	numberAttribute,
 	OnChanges,
 	OnDestroy,
 	OnInit,
-	Output,
 	SimpleChanges,
 	TemplateRef,
 	ViewContainerRef,
 	inject,
+	input,
+	output,
 } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { AbstractControl, ControlContainer, FormControl, FormGroup, FormGroupName } from '@angular/forms';
@@ -25,50 +27,57 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
 	viewContainerRef = inject(ViewContainerRef);
 	private parentForm = inject(ControlContainer, { optional: true, host: true, skipSelf: true });
 
-	@Input('autocomplete') public autocomplete = false;
-	@Input('auto-complete-placeholder') public autoCompletePlaceholder: string;
-	@Input('source') public source: any;
-	@Input('path-to-data') public pathToData: string;
-	@Input('min-chars') public minChars: number;
-	@Input('display-property-name') public displayPropertyName: string;
-	@Input('accept-user-input') public acceptUserInput = true;
-	@Input('max-num-list') public maxNumList: string;
-	@Input('select-value-of') public selectValueOf: string;
-	@Input('loading-template') public loadingTemplate = null;
-	@Input('list-formatter') public listFormatter;
-	@Input('loading-text') public loadingText = 'Loading';
-	@Input('blank-option-text') public blankOptionText: string;
-	@Input('no-match-found-text') public noMatchFoundText: string;
-	@Input('value-formatter') public valueFormatter: any;
-	@Input('tab-to-select') public tabToSelect = true;
-	@Input('select-on-blur') public selectOnBlur = false;
-	@Input('match-formatted') public matchFormatted = false;
-	@Input('auto-select-first-item') public autoSelectFirstItem = false;
-	@Input('open-on-focus') public openOnFocus = true;
-	@Input('close-on-focusout') public closeOnFocusOut = true;
-	@Input('re-focus-after-select') public reFocusAfterSelect = true;
-	@Input('header-item-template') public headerItemTemplate = null;
-	@Input('ignore-accents') public ignoreAccents = true;
+	public autocomplete = input(false, { transform: booleanAttribute });
+	public autoCompletePlaceholder = input<string | undefined>(undefined, { alias: 'auto-complete-placeholder' });
+	public source = input<any>();
+	public pathToData = input<string | undefined>(undefined, { alias: 'path-to-data' });
+	public minChars = input(0, { alias: 'min-chars', transform: numberAttribute });
+	public displayPropertyName = input<string | undefined>(undefined, { alias: 'display-property-name' });
+	public acceptUserInput = input(true, { alias: 'accept-user-input', transform: booleanAttribute });
+	public maxNumList = input(undefined, {
+		alias: 'max-num-list',
+		transform: (value: string | number | undefined) => (value == null ? undefined : numberAttribute(value)),
+	});
+	public selectValueOf = input<string | undefined>(undefined, { alias: 'select-value-of' });
+	public loadingTemplate = input<string | null>(null, { alias: 'loading-template' });
+	public listFormatter = input<((arg: any) => string) | string | undefined>(undefined, { alias: 'list-formatter' });
+	public loadingText = input('Loading', { alias: 'loading-text' });
+	public blankOptionText = input<string | undefined>(undefined, { alias: 'blank-option-text' });
+	public noMatchFoundText = input<string | undefined>(undefined, { alias: 'no-match-found-text' });
+	public valueFormatter = input<any>(undefined, { alias: 'value-formatter' });
+	public tabToSelect = input(true, { alias: 'tab-to-select', transform: booleanAttribute });
+	public selectOnBlur = input(false, { alias: 'select-on-blur', transform: booleanAttribute });
+	public matchFormatted = input(false, { alias: 'match-formatted', transform: booleanAttribute });
+	public autoSelectFirstItem = input(false, { alias: 'auto-select-first-item', transform: booleanAttribute });
+	public openOnFocus = input(true, { alias: 'open-on-focus', transform: booleanAttribute });
+	public closeOnFocusOut = input(true, { alias: 'close-on-focusout', transform: booleanAttribute });
+	public reFocusAfterSelect = input(true, { alias: 're-focus-after-select', transform: booleanAttribute });
+	public headerItemTemplate = input<string | null>(null, { alias: 'header-item-template' });
+	public ignoreAccents = input(true, { alias: 'ignore-accents', transform: booleanAttribute });
 	// Angular template alternatives to the string `list-formatter` / `header-item-template`,
 	// forwarded to the dropdown component (they take precedence when provided).
-	@Input() public itemTemplate: TemplateRef<{ $implicit: any; index: number }>;
-	@Input() public headerTemplate: TemplateRef<void>;
+	public itemTemplate = input<TemplateRef<{ $implicit: any; index: number }> | null>(null);
+	public headerTemplate = input<TemplateRef<void> | null>(null);
 
+	// Value / forms bindings are still classic @Input()s: `ngModel` is reassigned internally
+	// (read-only signal inputs forbid that) and the whole group is slated to be replaced by a
+	// ControlValueAccessor in a later phase.
 	@Input() public ngModel: string;
 	@Input('formControlName') public formControlName: string;
 	// if [formControl] is used on the anchor where our directive is sitting
 	// a form is not necessary to use a formControl we should also support this
 	@Input('formControl') public extFormControl: FormControl;
-	@Input('z-index') public zIndex = '1';
-	@Input('is-rtl') public isRtl = false;
+
+	public zIndex = input(1, { alias: 'z-index', transform: numberAttribute });
+	public isRtl = input(false, { alias: 'is-rtl', transform: booleanAttribute });
 	// 'down' / 'up' force the dropdown below / above the input; 'auto' (default) opens
 	// below unless the input sits near the bottom of the viewport.
-	@Input('open-direction') public openDirection: 'auto' | 'up' | 'down' = 'auto';
+	public openDirection = input<'auto' | 'up' | 'down'>('auto', { alias: 'open-direction' });
 
-	@Output() public ngModelChange = new EventEmitter();
-	@Output() public valueChanged = new EventEmitter();
-	@Output() public customSelected = new EventEmitter();
-	@Output() public noMatchFound = new EventEmitter<void>();
+	public ngModelChange = output<any>();
+	public valueChanged = output<any>();
+	public customSelected = output<any>();
+	public noMatchFound = output<void>();
 
 	private componentRef: ComponentRef<NguiAutoCompleteComponent>;
 	private wrapperEl: HTMLElement;
@@ -131,15 +140,15 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
 		// so that it displays correctly
 		this.inputEl = this.el.tagName === 'INPUT' ? (this.el as HTMLInputElement) : this.el.querySelector('input');
 
-		if (this.openOnFocus) {
+		if (this.openOnFocus()) {
 			this.inputEl.addEventListener('focus', (e) => this.showAutoCompleteDropdown(e));
 		}
 
-		if (this.closeOnFocusOut) {
+		if (this.closeOnFocusOut()) {
 			this.inputEl.addEventListener('focusout', (e) => this.hideAutoCompleteDropdown(e));
 		}
 
-		if (!this.autocomplete) {
+		if (!this.autocomplete()) {
 			this.inputEl.setAttribute('autocomplete', 'off');
 		}
 		this.inputEl.addEventListener('blur', (e) => {
@@ -180,28 +189,30 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
 
 		const component = this.componentRef.instance;
 		component.keyword = this.inputEl.value;
-		component.showInputTag = false; // Do NOT display autocomplete input tag separately
 
-		component.pathToData = this.pathToData;
-		component.minChars = this.minChars;
-		component.source = this.source;
-		component.placeholder = this.autoCompletePlaceholder;
-		component.acceptUserInput = this.acceptUserInput;
-		component.maxNumList = parseInt(this.maxNumList, 10);
+		// Forward inputs to the dynamically created dropdown component. Signal inputs are
+		// read-only from outside, so we set them through the ComponentRef.
+		this.componentRef.setInput('show-input-tag', false); // Do NOT display autocomplete input tag separately
+		this.componentRef.setInput('path-to-data', this.pathToData());
+		this.componentRef.setInput('min-chars', this.minChars());
+		this.componentRef.setInput('source', this.source());
+		this.componentRef.setInput('placeholder', this.autoCompletePlaceholder());
+		this.componentRef.setInput('accept-user-input', this.acceptUserInput());
+		this.componentRef.setInput('max-num-list', this.maxNumList());
 
-		component.loadingText = this.loadingText;
-		component.loadingTemplate = this.loadingTemplate;
-		component.listFormatter = this.listFormatter;
-		component.blankOptionText = this.blankOptionText;
-		component.noMatchFoundText = this.noMatchFoundText;
-		component.tabToSelect = this.tabToSelect;
-		component.selectOnBlur = this.selectOnBlur;
-		component.matchFormatted = this.matchFormatted;
-		component.autoSelectFirstItem = this.autoSelectFirstItem;
-		component.headerItemTemplate = this.headerItemTemplate;
-		component.itemTemplate = this.itemTemplate;
-		component.headerTemplate = this.headerTemplate;
-		component.ignoreAccents = this.ignoreAccents;
+		this.componentRef.setInput('loading-text', this.loadingText());
+		this.componentRef.setInput('loading-template', this.loadingTemplate());
+		this.componentRef.setInput('list-formatter', this.listFormatter());
+		this.componentRef.setInput('blank-option-text', this.blankOptionText());
+		this.componentRef.setInput('no-match-found-text', this.noMatchFoundText());
+		this.componentRef.setInput('tab-to-select', this.tabToSelect());
+		this.componentRef.setInput('select-on-blur', this.selectOnBlur());
+		this.componentRef.setInput('match-formatted', this.matchFormatted());
+		this.componentRef.setInput('auto-select-first-item', this.autoSelectFirstItem());
+		this.componentRef.setInput('header-item-template', this.headerItemTemplate());
+		this.componentRef.setInput('itemTemplate', this.itemTemplate());
+		this.componentRef.setInput('headerTemplate', this.headerTemplate());
+		this.componentRef.setInput('ignore-accents', this.ignoreAccents());
 
 		this.dropdownSubs.unsubscribe();
 		this.dropdownSubs = new Subscription();
@@ -236,11 +247,11 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
 		if (this.componentRef) {
 			const component = this.componentRef.instance;
 
-			if (this.selectOnBlur) {
+			if (this.selectOnBlur()) {
 				component.selectOne(component.filteredList[component.itemIndex]);
 			}
 
-			if (this.closeOnFocusOut) {
+			if (this.closeOnFocusOut()) {
 				this.hideAutoCompleteDropdown(event);
 			}
 		}
@@ -250,17 +261,17 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
 		if (this.componentRef) {
 			let currentItem: any;
 			const hasRevertValue = typeof this.revertValue !== 'undefined';
-			if (this.inputEl && hasRevertValue && this.acceptUserInput === false) {
+			if (this.inputEl && hasRevertValue && this.acceptUserInput() === false) {
 				currentItem = this.componentRef.instance.findItemFromSelectValue(this.inputEl.value);
 			}
 			this.dropdownSubs.unsubscribe();
 			this.componentRef.destroy();
 			this.componentRef = undefined;
 
-			if (this.inputEl && hasRevertValue && this.acceptUserInput === false && currentItem === null && this.inputEl.value !== '') {
+			if (this.inputEl && hasRevertValue && this.acceptUserInput() === false && currentItem === null && this.inputEl.value !== '') {
 				this.selectNewValue(this.revertValue);
 				currentItem = this.revertValue;
-			} else if (this.inputEl && this.acceptUserInput === true && typeof currentItem === 'undefined' && event && event.target.value) {
+			} else if (this.inputEl && this.acceptUserInput() === true && typeof currentItem === 'undefined' && event && event.target.value) {
 				this.enterNewText(event.target.value);
 			}
 			this.revertValue = currentItem;
@@ -273,11 +284,11 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
 		if (this.componentRef) {
 			/* setting width/height auto complete */
 			const thisInputElBCR = this.inputEl.getBoundingClientRect();
-			const directionOfStyle = this.isRtl ? 'right' : 'left';
+			const directionOfStyle = this.isRtl() ? 'right' : 'left';
 
 			this.acDropdownEl.style.width = thisInputElBCR.width + 'px';
 			this.acDropdownEl.style.position = 'absolute';
-			this.acDropdownEl.style.zIndex = this.zIndex;
+			this.acDropdownEl.style.zIndex = '' + this.zIndex();
 			this.acDropdownEl.style[directionOfStyle] = '0';
 			this.acDropdownEl.style.display = 'inline-block';
 
@@ -297,10 +308,10 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
 	// 'auto' keeps the historic heuristic: open above only when the input is within
 	// ~100px of the viewport bottom.
 	private shouldOpenUp(inputBCR: DOMRect): boolean {
-		if (this.openDirection === 'up') {
+		if (this.openDirection() === 'up') {
 			return true;
 		}
-		if (this.openDirection === 'down') {
+		if (this.openDirection() === 'down') {
 			return false;
 		}
 		return inputBCR.bottom + 100 > window.innerHeight;
@@ -309,22 +320,24 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
 	public setToStringFunction(item: any): any {
 		if (item && typeof item === 'object') {
 			let displayVal;
+			const valueFormatter = this.valueFormatter();
+			const listFormatter = this.listFormatter();
 
-			if (typeof this.valueFormatter === 'string') {
-				const matches = this.valueFormatter.match(/[a-zA-Z0-9_\$]+/g);
-				let formatted = this.valueFormatter;
+			if (typeof valueFormatter === 'string') {
+				const matches = valueFormatter.match(/[a-zA-Z0-9_\$]+/g);
+				let formatted = valueFormatter;
 				if (matches && typeof item !== 'string') {
 					matches.forEach((key) => {
 						formatted = formatted.replace(key, item[key]);
 					});
 				}
 				displayVal = formatted;
-			} else if (typeof this.valueFormatter === 'function') {
-				displayVal = this.valueFormatter(item);
-			} else if (this.displayPropertyName) {
-				displayVal = item[this.displayPropertyName];
-			} else if (typeof this.listFormatter === 'string' && this.listFormatter.match(/^\w+$/)) {
-				displayVal = item[this.listFormatter];
+			} else if (typeof valueFormatter === 'function') {
+				displayVal = valueFormatter(item);
+			} else if (this.displayPropertyName()) {
+				displayVal = item[this.displayPropertyName()];
+			} else if (typeof listFormatter === 'string' && listFormatter.match(/^\w+$/)) {
+				displayVal = item[listFormatter];
 			} else {
 				displayVal = item.value;
 			}
@@ -343,8 +356,9 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
 
 		// make return value
 		let val = item;
-		if (this.selectValueOf && item !== null && typeof item === 'object') {
-			val = item[this.selectValueOf];
+		const selectValueOf = this.selectValueOf();
+		if (selectValueOf && item !== null && typeof item === 'object') {
+			val = item[selectValueOf];
 		}
 		if ((this.parentForm && this.formControlName) || this.extFormControl) {
 			if (!!val) {
@@ -357,7 +371,7 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
 		this.valueChanged.emit(val);
 		this.hideAutoCompleteDropdown();
 		setTimeout(() => {
-			if (this.reFocusAfterSelect) {
+			if (this.reFocusAfterSelect()) {
 				this.inputEl.focus();
 			}
 
@@ -369,7 +383,7 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
 		this.customSelected.emit(text);
 		this.hideAutoCompleteDropdown();
 		setTimeout(() => {
-			if (this.reFocusAfterSelect) {
+			if (this.reFocusAfterSelect()) {
 				this.inputEl.focus();
 			}
 

--- a/projects/auto-complete/src/lib/auto-complete.service.ts
+++ b/projects/auto-complete/src/lib/auto-complete.service.ts
@@ -9,7 +9,7 @@ export class NguiAutoCompleteService {
 
 	public source: string;
 	public pathToData: string;
-	public listFormatter: (arg: any) => string;
+	public listFormatter: ((arg: any) => string) | undefined;
 
 	public filter(list: any[], keyword: string, matchFormatted: boolean, accentInsensitive: boolean) {
 		const objectString = (el) => (matchFormatted ? this.getFormattedListItem(el).toLowerCase() : JSON.stringify(el).toLowerCase());


### PR DESCRIPTION
## Phase A — Signal inputs/outputs (non-breaking)

First step of the post-Angular-21 API modernization. **No template-facing breaking changes** — every input keeps its existing name/alias, so consumer templates are unchanged.

### Changed
- `@Input()` → **`input()`** and `@Output()` → **`output()`** across the component and directive; the component's `@ViewChild`s → **`viewChild()`** signal queries.
- **Typed attribute coercion:** `numberAttribute` on `min-chars` / `max-num-list` / `z-index`, `booleanAttribute` on boolean inputs — both `min-chars="2"` and `[min-chars]="2"` are now correctly typed (and the manual `parseInt` for `max-num-list` is gone).
- The directive forwards inputs to the dynamically created dropdown via **`ComponentRef.setInput()`** (component inputs are now read-only signals).
- Widened `NguiAutoCompleteService.listFormatter` to its honest `| undefined` type; untyped `EventEmitter`s became `output<any>()` to preserve the previous `any` payload.
- Library `tslib` floor `^2.7.0` → `^2.8.1`.

### Deliberately *not* changed (yet)
- The value/forms inputs — `ngModel`, `formControl`, `formControlName` — stay classic `@Input()`. `ngModel` is reassigned internally (read-only signal inputs forbid that), and the whole group is slated to be replaced by a `ControlValueAccessor` in a later phase.

### Consumer impact
Only code that reaches into a component/**directive instance** programmatically is affected: those input properties are now read-only signals — call them (`cmp.minChars()`) instead of reading a field. README is unchanged because all documented bindings keep working as-is.

### Notes
- Folds into the still-unpublished `21.0.0` (CHANGELOG entry expanded; no new version header).
- Validation: `build-lib:prod`, `build-docs` (no warnings), `lint`, unit tests (lib 9/9, demo 5/5), `format:check` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
