### PR TITLE
refactor(lib): OnPush + signal state for the dropdown component (Phase B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project follows [Angular version numbers](https://angular.dev/reference
 - **Typed attribute coercion.** Numeric inputs (`min-chars`, `max-num-list`, `z-index`) now use
   `numberAttribute` and boolean inputs use `booleanAttribute`, so string-attribute forms (`min-chars="2"`)
   and bound forms (`[min-chars]="2"`) are both correctly typed.
+- **`OnPush` dropdown component.** `NguiAutoCompleteComponent` now uses `ChangeDetectionStrategy.OnPush`
+  and its internal state (`dropdownVisible`, `isLoading`, `filteredList`, `minCharsEntered`, `itemIndex`)
+  is signal-based, so remote/async results and directive-driven updates refresh reliably with less change
+  detection work. No public API change.
 - Bumped the library's own `tslib` dependency floor to `^2.8.1`.
 
 ### Internal (development tooling only — no impact on consumers)

--- a/projects/auto-complete/src/lib/auto-complete.component.html
+++ b/projects/auto-complete/src/lib/auto-complete.component.html
@@ -14,37 +14,37 @@
 	}
 
 	<!-- dropdown that user can select -->
-	@if (dropdownVisible) {
+	@if (dropdownVisible()) {
 		<ul [class.empty]="emptyList" [class.dropup]="openDirection() === 'up'">
-			@if (isLoading && loadingTemplate()) {
+			@if (isLoading() && loadingTemplate()) {
 				<li class="loading" [innerHTML]="loadingTemplate()"></li>
 			}
-			@if (isLoading && !loadingTemplate()) {
+			@if (isLoading() && !loadingTemplate()) {
 				<li class="loading">{{ loadingText() }}</li>
 			}
-			@if (minCharsEntered && !isLoading && !filteredList.length && noMatchFoundText() !== '') {
+			@if (minCharsEntered() && !isLoading() && !filteredList().length && noMatchFoundText() !== '') {
 				<li (mousedown)="selectOne('')" class="no-match-found">{{ noMatchFoundText() ?? 'No Result Found' }}</li>
 			}
-			@if (headerTemplate() && filteredList.length) {
+			@if (headerTemplate() && filteredList().length) {
 				<li class="header-item">
 					<ng-container [ngTemplateOutlet]="headerTemplate()"></ng-container>
 				</li>
-			} @else if (headerItemTemplate() && filteredList.length) {
+			} @else if (headerItemTemplate() && filteredList().length) {
 				<li class="header-item" [innerHTML]="headerItemTemplate()"></li>
 			}
-			@if (blankOptionText() && filteredList.length) {
+			@if (blankOptionText() && filteredList().length) {
 				<li (mousedown)="selectOne('')" class="blank-item">{{ blankOptionText() }}</li>
 			}
-			@for (item of filteredList; track trackByIndex(i, item); let i = $index) {
+			@for (item of filteredList(); track trackByIndex(i, item); let i = $index) {
 				@if (itemTemplate()) {
-					<li class="item" (mousedown)="selectOne(item)" [ngClass]="{ selected: i === itemIndex }">
+					<li class="item" (mousedown)="selectOne(item)" [ngClass]="{ selected: i === itemIndex() }">
 						<ng-container [ngTemplateOutlet]="itemTemplate()" [ngTemplateOutletContext]="{ $implicit: item, index: i }"></ng-container>
 					</li>
 				} @else {
 					<li
 						class="item"
 						(mousedown)="selectOne(item)"
-						[ngClass]="{ selected: i === itemIndex }"
+						[ngClass]="{ selected: i === itemIndex() }"
 						[innerHtml]="autoComplete.getFormattedListItem(item)"></li>
 				}
 			}

--- a/projects/auto-complete/src/lib/auto-complete.component.spec.ts
+++ b/projects/auto-complete/src/lib/auto-complete.component.spec.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, ViewChild } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -36,7 +36,7 @@ describe('NguiAutoCompleteComponent', () => {
 	});
 
 	it('should default open-direction to "auto" and not mark the dropdown as dropup', () => {
-		component.dropdownVisible = true;
+		component.dropdownVisible.set(true);
 		fixture.detectChanges();
 		const dropdown: HTMLElement = fixture.nativeElement.querySelector('ul');
 		expect(component.openDirection()).toBe('auto');
@@ -45,7 +45,7 @@ describe('NguiAutoCompleteComponent', () => {
 
 	it('should add the "dropup" class when open-direction is "up"', () => {
 		fixture.componentRef.setInput('open-direction', 'up');
-		component.dropdownVisible = true;
+		component.dropdownVisible.set(true);
 		fixture.detectChanges();
 		const dropdown: HTMLElement = fixture.nativeElement.querySelector('ul');
 		expect(dropdown.classList.contains('dropup')).toBe(true);
@@ -71,13 +71,10 @@ describe('NguiAutoCompleteComponent itemTemplate', () => {
 
 		const acDebug = fixture.debugElement.query(By.directive(NguiAutoCompleteComponent));
 		const ac = fixture.componentInstance.autoComplete;
-		ac.filteredList = ['Alpha', 'Beta'];
-		ac.dropdownVisible = true;
-		// These fields are mutated out of band (not via an input or event), so Angular's
-		// change detection has no signal that the child view is dirty. Without marking it,
-		// Angular 21's apply pass skips the clean child while dev-mode checkNoChanges still
-		// re-evaluates it — surfacing a false ExpressionChangedAfterItHasBeenChecked (NG0100).
-		acDebug.injector.get(ChangeDetectorRef).markForCheck();
+		// Writing these signals marks the OnPush view dirty, so a plain detectChanges() refreshes it
+		// (no manual markForCheck needed, unlike when these were plain fields).
+		ac.filteredList.set(['Alpha', 'Beta']);
+		ac.dropdownVisible.set(true);
 		fixture.detectChanges();
 
 		const rows = acDebug.nativeElement.querySelectorAll('li.item');

--- a/projects/auto-complete/src/lib/auto-complete.component.ts
+++ b/projects/auto-complete/src/lib/auto-complete.component.ts
@@ -1,5 +1,6 @@
 import {
 	booleanAttribute,
+	ChangeDetectionStrategy,
 	Component,
 	ElementRef,
 	numberAttribute,
@@ -9,6 +10,7 @@ import {
 	inject,
 	input,
 	output,
+	signal,
 	viewChild,
 } from '@angular/core';
 import { NguiAutoCompleteService } from './auto-complete.service';
@@ -21,6 +23,7 @@ import { NgClass, NgTemplateOutlet } from '@angular/common';
 	templateUrl: './auto-complete.component.html',
 	styleUrls: ['./auto-complete.component.scss'],
 	encapsulation: ViewEncapsulation.None,
+	changeDetection: ChangeDetectionStrategy.OnPush,
 	providers: [NguiAutoCompleteService],
 	imports: [FormsModule, NgClass, NgTemplateOutlet],
 })
@@ -71,12 +74,12 @@ export class NguiAutoCompleteComponent implements OnInit {
 	public autoCompleteInput = viewChild<ElementRef>('autoCompleteInput');
 	public autoCompleteContainer = viewChild<ElementRef>('autoCompleteContainer');
 
-	public dropdownVisible = false;
-	public isLoading = false;
+	public dropdownVisible = signal(false);
+	public isLoading = signal(false);
 
-	public filteredList: any[] = [];
-	public minCharsEntered = false;
-	public itemIndex: number = null;
+	public filteredList = signal<any[]>([]);
+	public minCharsEntered = signal(false);
+	public itemIndex = signal<number | null>(null);
 	public keyword: string;
 
 	private el: HTMLElement; // this component  element `<ngui-auto-complete>`
@@ -108,7 +111,7 @@ export class NguiAutoCompleteComponent implements OnInit {
 		this.autoComplete.pathToData = this.pathToData();
 		this.autoComplete.listFormatter = this.listFormatter();
 		if (this.autoSelectFirstItem()) {
-			this.itemIndex = 0;
+			this.itemIndex.set(0);
 		}
 		setTimeout(() => {
 			const input = this.autoCompleteInput();
@@ -134,27 +137,27 @@ export class NguiAutoCompleteComponent implements OnInit {
 	};
 
 	public showDropdownList(event: any): void {
-		this.dropdownVisible = true;
+		this.dropdownVisible.set(true);
 		this.reloadList(event.target.value);
 	}
 
 	public hideDropdownList(): void {
 		this.selectOnEnter = false;
-		this.dropdownVisible = false;
+		this.dropdownVisible.set(false);
 	}
 
 	public findItemFromSelectValue(selectText: string): any {
-		const matchingItems = this.filteredList.filter((item) => '' + item === selectText);
+		const matchingItems = this.filteredList().filter((item) => '' + item === selectText);
 		return matchingItems.length ? matchingItems[0] : null;
 	}
 
 	public reloadList(keyword: string): void {
-		this.filteredList = [];
+		this.filteredList.set([]);
 		if (keyword.length < (this.minChars() || 0)) {
-			this.minCharsEntered = false;
+			this.minCharsEntered.set(false);
 			return;
 		} else {
-			this.minCharsEntered = true;
+			this.minCharsEntered.set(true);
 		}
 
 		const maxNumList = this.maxNumList();
@@ -162,17 +165,18 @@ export class NguiAutoCompleteComponent implements OnInit {
 
 		if (this.isSrcArr()) {
 			// local source
-			this.isLoading = false;
-			this.filteredList = this.autoComplete.filter(source, keyword, this.matchFormatted(), this.ignoreAccents());
+			this.isLoading.set(false);
+			let list = this.autoComplete.filter(source, keyword, this.matchFormatted(), this.ignoreAccents());
 			if (maxNumList) {
-				this.filteredList = this.filteredList.slice(0, maxNumList);
+				list = list.slice(0, maxNumList);
 			}
-			if (this.minCharsEntered && !this.filteredList.length) {
+			this.filteredList.set(list);
+			if (this.minCharsEntered() && !this.filteredList().length) {
 				this.noMatchFound.emit();
 			}
 		} else {
 			// remote source
-			this.isLoading = true;
+			this.isLoading.set(true);
 
 			if (typeof source === 'function') {
 				// custom function that returns observable
@@ -182,36 +186,38 @@ export class NguiAutoCompleteComponent implements OnInit {
 							const paths = this.pathToData().split('.');
 							paths.forEach((prop) => (resp = resp[prop]));
 						}
-						this.filteredList = resp;
+						let list = resp;
 						if (maxNumList) {
-							this.filteredList = this.filteredList.slice(0, maxNumList);
+							list = list.slice(0, maxNumList);
 						}
-						this.isLoading = false;
-						if (this.minCharsEntered && !this.filteredList.length) {
+						this.filteredList.set(list);
+						this.isLoading.set(false);
+						if (this.minCharsEntered() && !this.filteredList().length) {
 							this.noMatchFound.emit();
 						}
 					},
 					error: (error) => {
 						console.warn(error);
-						this.isLoading = false;
+						this.isLoading.set(false);
 					},
 				});
 			} else {
 				// remote source
 				this.autoComplete.getRemoteData(keyword).subscribe({
 					next: (resp) => {
-						this.filteredList = resp ? resp : [];
+						let list = resp ? resp : [];
 						if (maxNumList) {
-							this.filteredList = this.filteredList.slice(0, maxNumList);
+							list = list.slice(0, maxNumList);
 						}
-						this.isLoading = false;
-						if (this.minCharsEntered && !this.filteredList.length) {
+						this.filteredList.set(list);
+						this.isLoading.set(false);
+						if (this.minCharsEntered() && !this.filteredList().length) {
 							this.noMatchFound.emit();
 						}
 					},
 					error: (error) => {
 						console.warn(error);
-						this.isLoading = false;
+						this.isLoading.set(false);
 					},
 				});
 			}
@@ -232,14 +238,14 @@ export class NguiAutoCompleteComponent implements OnInit {
 
 	public blurHandler(evt: any) {
 		if (this.selectOnBlur()) {
-			this.selectOne(this.filteredList[this.itemIndex]);
+			this.selectOne(this.filteredList()[this.itemIndex()]);
 		}
 
 		this.hideDropdownList();
 	}
 
 	public inputElKeyHandler = (evt: any) => {
-		const totalNumItem = this.filteredList.length;
+		const totalNumItem = this.filteredList().length;
 
 		if (!this.selectOnEnter && this.autoSelectFirstItem() && 0 !== totalNumItem) {
 			this.selectOnEnter = true;
@@ -256,8 +262,8 @@ export class NguiAutoCompleteComponent implements OnInit {
 					return;
 				}
 				this.selectOnEnter = true;
-				this.itemIndex = (totalNumItem + this.itemIndex - 1) % totalNumItem;
-				this.scrollToView(this.itemIndex);
+				this.itemIndex.set((totalNumItem + this.itemIndex() - 1) % totalNumItem);
+				this.scrollToView(this.itemIndex());
 				break;
 
 			case 40: // DOWN, select the next li el or the first one
@@ -265,23 +271,22 @@ export class NguiAutoCompleteComponent implements OnInit {
 					return;
 				}
 				this.selectOnEnter = true;
-				this.dropdownVisible = true;
-				let sum = this.itemIndex;
-				sum = this.itemIndex === null ? 0 : sum + 1;
-				this.itemIndex = (totalNumItem + sum) % totalNumItem;
-				this.scrollToView(this.itemIndex);
+				this.dropdownVisible.set(true);
+				const sum = this.itemIndex() === null ? 0 : this.itemIndex() + 1;
+				this.itemIndex.set((totalNumItem + sum) % totalNumItem);
+				this.scrollToView(this.itemIndex());
 				break;
 
 			case 13: // ENTER, choose it!!
 				if (this.selectOnEnter) {
-					this.selectOne(this.filteredList[this.itemIndex]);
+					this.selectOne(this.filteredList()[this.itemIndex()]);
 				}
 				evt.preventDefault();
 				break;
 
 			case 9: // TAB, choose if tab-to-select is enabled
 				if (this.tabToSelect()) {
-					this.selectOne(this.filteredList[this.itemIndex]);
+					this.selectOne(this.filteredList()[this.itemIndex()]);
 				}
 				break;
 		}
@@ -305,6 +310,10 @@ export class NguiAutoCompleteComponent implements OnInit {
 	}
 
 	get emptyList(): boolean {
-		return !(this.isLoading || (this.minCharsEntered && !this.isLoading && !this.filteredList.length) || this.filteredList.length);
+		return !(
+			this.isLoading() ||
+			(this.minCharsEntered() && !this.isLoading() && !this.filteredList().length) ||
+			this.filteredList().length
+		);
 	}
 }

--- a/projects/auto-complete/src/lib/auto-complete.directive.ts
+++ b/projects/auto-complete/src/lib/auto-complete.directive.ts
@@ -239,7 +239,7 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
 		setTimeout(() => {
 			component.reloadList(this.inputEl.value);
 			this.styleAutoCompleteDropdown();
-			component.dropdownVisible = true;
+			component.dropdownVisible.set(true);
 		});
 	};
 
@@ -248,7 +248,7 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
 			const component = this.componentRef.instance;
 
 			if (this.selectOnBlur()) {
-				component.selectOne(component.filteredList[component.itemIndex]);
+				component.selectOne(component.filteredList()[component.itemIndex()]);
 			}
 
 			if (this.closeOnFocusOut()) {
@@ -408,7 +408,7 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
 	private inputEventHandler = (evt: any) => {
 		if (this.componentRef) {
 			const component = this.componentRef.instance;
-			component.dropdownVisible = true;
+			component.dropdownVisible.set(true);
 			component.keyword = evt.target.value;
 			component.reloadListInDelay(evt);
 		} else {


### PR DESCRIPTION
## Summary

Phase B of the post-Angular-21 modernization: make the dropdown component's internal state signal-based and switch it to `OnPush` change detection. No public API change.

## Area

- [x] 📦 Library (`projects/auto-complete`)

## Changes

- `NguiAutoCompleteComponent` internal state — `dropdownVisible`, `isLoading`, `filteredList`, `minCharsEntered`, `itemIndex` — converted from plain fields to `signal()`s; reads/writes updated across the component and template.
- Component switched to `ChangeDetectionStrategy.OnPush`.
- The directive's out-of-band updates to that state now use the signal API (e.g. `component.dropdownVisible.set(true)`, `component.filteredList()[component.itemIndex()]`).
- Spec: state set via signals; **removed the `markForCheck` workaround** — signal writes now mark the OnPush view dirty on their own (the earlier Phase-4 NG0100 cause is gone).

## Impact

None for consumers — templates, inputs, outputs and behavior are unchanged. Internally, async/remote results and directive-driven updates now refresh reliably via signals while doing less change-detection work.

## How to test

```bash
npm run build-lib:prod
npm run build-docs
npm run lint
npx ng test auto-complete --watch=false --browsers=ChromeHeadless
npx ng test demo --watch=false --browsers=ChromeHeadless
npm run format:check
```

Manual: in the demo, type to load suggestions (local and remote sources), arrow-key navigation, select-on-blur, and the custom item-template card — all should behave as before.

## Checklist

- [x] Scope is small and single-concern
- [x] Conventional Commit title
- [x] `build-lib:prod`, `build-docs`, `lint`, unit tests (lib 9/9 + demo 5/5) and `format:check` all pass
- [x] **CHANGELOG.md** updated (21.0.0 entry)
- [ ] README.md — n/a (no public API/usage change)
- [ ] Breaking changes — none
- [x] No generated `build-info.ts` timestamp committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
