### PR TITLE
feat(lib)!: ControlValueAccessor + [(value)] model (Phase C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,23 @@ and this project follows [Angular version numbers](https://angular.dev/reference
   standalone `NguiAutoCompleteComponent` / `NguiAutoCompleteDirective` directly instead:
   `imports: [NguiAutoCompleteComponent, NguiAutoCompleteDirective]`. Apps that still need the NgModule
   can stay on `@ngui/auto-complete@20`, which retained it.
+- **The directive is now a `ControlValueAccessor`.** `NguiAutoCompleteDirective` implements
+  `ControlValueAccessor` and provides `NG_VALUE_ACCESSOR`, so `[(ngModel)]`, `[formControl]` and
+  `formControlName` integrate through Angular forms (with proper `valueChanges`, `touched`/`dirty` state).
+  Consequences (see [`MIGRATION.md`](./MIGRATION.md) for before/after):
+  - Removed the directive's bespoke **`ngModel` input** and its **`(ngModelChange)`** and
+    **`(valueChanged)`** outputs. Use `[(ngModel)]` (Angular still emits `(ngModelChange)`) or a reactive
+    form. `(valueChanged)` has no direct replacement — use `(ngModelChange)` or the control's `valueChanges`.
+  - Removed the directive's custom **`[formControl]` / `formControlName`** inputs. The standard Angular
+    directives now drive it directly — same template syntax, now with full form integration.
+  - **Wrapper-`<div>` usage:** bind the value on the host
+    (`<div ngui-auto-complete [(ngModel)]="x"><input></div>`) instead of on a separate inner `<input>`.
+    Direct `<input ngui-auto-complete [(ngModel)]="x">` is unchanged.
+- **Removed the unused `textEntered` output** from `NguiAutoCompleteComponent` (it was never emitted).
+
+### Added
+- **`[(value)]` two-way binding on `NguiAutoCompleteComponent`.** The standalone component now exposes a
+  `value` model — e.g. `<ngui-auto-complete [(value)]="myValue">`. `(valueSelected)` continues to fire.
 
 ### Changed
 - **Upgraded to Angular 21** (`@angular/*` 21.2.x, `@angular/material` + `@angular/cdk` 21.2.x).

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,90 @@
+# Migration Guide
+
+Upgrade notes for breaking changes between major versions of `@ngui/auto-complete`. The major version
+tracks the supported Angular major (`@ngui/auto-complete@N` ⇒ Angular `N`).
+
+---
+
+## v20 → v21
+
+### Requires Angular 21
+
+Update Angular to 21 first. Angular 20 and older projects must stay on `@ngui/auto-complete@20`.
+
+### `NguiAutoCompleteModule` was removed
+
+Import the standalone component/directive directly.
+
+```diff
+- import { NguiAutoCompleteModule } from '@ngui/auto-complete';
+- @NgModule({ imports: [NguiAutoCompleteModule] })
++ import { NguiAutoCompleteComponent, NguiAutoCompleteDirective } from '@ngui/auto-complete';
++ @Component({ imports: [NguiAutoCompleteComponent, NguiAutoCompleteDirective] })
+```
+
+Apps that still need the NgModule can stay on `@ngui/auto-complete@20`, which retained it.
+
+### The directive is now a `ControlValueAccessor`
+
+`NguiAutoCompleteDirective` integrates with Angular forms instead of exposing its own value input/outputs.
+`[(ngModel)]`, `[formControl]` and `formControlName` now drive it through the standard forms machinery
+(with proper `valueChanges`, `touched`/`dirty` state).
+
+**Direct-input `[(ngModel)]` usage is unchanged:**
+
+```html
+<input ngui-auto-complete [(ngModel)]="myValue" [source]="myArray" />
+```
+
+**Wrapper-`<div>` usage:** move the value binding onto the host element (it used to sit on a separate inner
+`<input>` with `(ngModelChange)` on the `<div>`):
+
+```diff
+- <div ngui-auto-complete [source]="myArray" (ngModelChange)="onSelect($event)">
+-   <input [(ngModel)]="myValue" />
+- </div>
++ <div ngui-auto-complete [source]="myArray" [(ngModel)]="myValue">
++   <input />
++ </div>
+```
+
+**Reactive forms** now work with the standard directives (same syntax, full integration):
+
+```html
+<input ngui-auto-complete [formControl]="cityControl" [source]="cities" />
+<input ngui-auto-complete formControlName="city" [source]="cities" />
+```
+
+### Removed: `(valueChanged)` output
+
+It duplicated `(ngModelChange)`. Use `(ngModelChange)` or, for reactive forms, the control's `valueChanges`.
+
+```diff
+- <input ngui-auto-complete [(ngModel)]="v" (valueChanged)="onChange($event)" [source]="s" />
++ <input ngui-auto-complete [(ngModel)]="v" (ngModelChange)="onChange($event)" [source]="s" />
+```
+
+`(customSelected)` (custom, not-in-list value) and `(noMatchFound)` are unchanged.
+
+### Removed: `(textEntered)` output on `NguiAutoCompleteComponent`
+
+It was never emitted, so it had no effect. Use `(valueSelected)` / `[(value)]` (see below) and
+`(customSelected)`.
+
+### New: `[(value)]` on `NguiAutoCompleteComponent` (optional)
+
+The standalone component gained a two-way `value` model. `(valueSelected)` still fires, so this is opt-in:
+
+```html
+<ngui-auto-complete [source]="myArray" [show-input-tag]="false" [(value)]="myValue"></ngui-auto-complete>
+```
+
+### Note: signal-based inputs (only affects programmatic access)
+
+All inputs are now signal `input()`s. Template bindings and their names/aliases are unchanged. Only code
+that reads an input off a component/directive **instance** is affected — call it as a signal:
+
+```diff
+- const n = autoCompleteRef.minChars;
++ const n = autoCompleteRef.minChars();
+```

--- a/README.md
+++ b/README.md
@@ -60,16 +60,29 @@ export class AppModule {}
 
 ### As a Directive
 
-Attach to any element containing an `input`:
+Attach to any element containing an `input`. The directive is a `ControlValueAccessor`, so it binds with
+`[(ngModel)]` like any form control:
 
 ```html
-<!-- On a wrapping div -->
-<div ngui-auto-complete [source]="myArray" (ngModelChange)="onSelect($event)">
-  <input [(ngModel)]="myValue" />
-</div>
-
 <!-- Directly on an input -->
 <input ngui-auto-complete [(ngModel)]="myValue" [source]="myArray" />
+
+<!-- On a wrapping div: put the value binding on the host element -->
+<div ngui-auto-complete [(ngModel)]="myValue" [source]="myArray">
+  <input />
+</div>
+```
+
+### Reactive forms
+
+Because the directive is a `ControlValueAccessor`, `[formControl]` and `formControlName` work directly:
+
+```html
+<input ngui-auto-complete [formControl]="cityControl" [source]="cities" />
+
+<form [formGroup]="form">
+  <input ngui-auto-complete formControlName="city" [source]="cities" />
+</form>
 ```
 
 ### As a Component
@@ -83,7 +96,7 @@ Use `<ngui-auto-complete>` directly, control its visibility with `@if`:
     [source]="myArray"
     [show-input-tag]="false"
     [show-dropdown-on-init]="true"
-    (valueSelected)="myValue = $event">
+    [(value)]="myValue">
   </ngui-auto-complete>
 }
 ```
@@ -130,7 +143,6 @@ works on both the component and the directive:
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
 | `source` | `any[] \| string \| Function` | — | **Required.** Array, URL string, or function returning `Observable` |
-| `ngModel` | `any` | — | Value binding |
 | `path-to-data` | `string` | — | Dot-path to array in HTTP response, e.g. `data.results` |
 | `min-chars` | `number` | `0` | Minimum characters before fetching remote data |
 | `max-num-list` | `number` | unlimited | Maximum suggestions to show |
@@ -159,12 +171,14 @@ works on both the component and the directive:
 | `open-direction` | `'auto' \| 'up' \| 'down'` | `'auto'` | Force the dropdown above (`up`) or below (`down`) the input. `auto` opens below unless the input is near the bottom of the viewport |
 | `z-index` | `string` | `'1'` | CSS z-index of the dropdown |
 
-### Directive Outputs
+### Directive value binding & outputs
+
+The selected value flows through Angular forms (the directive is a `ControlValueAccessor`): bind it with
+`[(ngModel)]`, `[formControl]` or `formControlName`. `(ngModelChange)` / the control's `valueChanges` fire
+on every accepted value.
 
 | Output | Payload | Description |
 |--------|---------|-------------|
-| `(ngModelChange)` | selected value | Fires when a list item or custom value is accepted |
-| `(valueChanged)` | selected value | Same as `ngModelChange` |
 | `(customSelected)` | keyword string | Fires when user accepts a value not in the list |
 | `(noMatchFound)` | `void` | Fires when the filtered list is empty and `min-chars` threshold is met — use it to show an "Add new…" affordance |
 
@@ -174,6 +188,7 @@ All directive inputs are supported plus:
 
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
+| `value` | `any` | — | Two-way bindable selected value: `[(value)]="myValue"` |
 | `show-input-tag` | `boolean` | `true` | Render an `<input>` inside the component |
 | `show-dropdown-on-init` | `boolean` | `false` | Open dropdown immediately when component appears |
 | `placeholder` | `string` | — | Placeholder text for the internal input |
@@ -185,9 +200,8 @@ All directive inputs are supported plus:
 
 | Output | Payload | Description |
 |--------|---------|-------------|
-| `(valueSelected)` | selected value | Fires when a list item is selected |
+| `(valueSelected)` | selected value | Fires when a list item is selected (or use `[(value)]`) |
 | `(customSelected)` | keyword string | Fires on custom (non-list) value entry |
-| `(textEntered)` | string | Fires when user enters text |
 | `(noMatchFound)` | `void` | Fires when the filtered list is empty and `min-chars` threshold is met — use it to show an "Add new…" affordance |
 
 ---

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build-lib:prod": "ng build auto-complete --configuration production && npm run copy-lib",
     "prebuild-docs": "npm run generate-build-info",
     "build-docs": "ng build demo --configuration production",
-    "copy-lib": "copyfiles -f LICENSE.md README.md CHANGELOG.md dist/",
+    "copy-lib": "copyfiles -f LICENSE.md README.md CHANGELOG.md MIGRATION.md dist/",
     "cypress:open": "ng run demo:cypress-open",
     "cypress:run": "ng run demo:cypress-run"
   },

--- a/projects/auto-complete/src/lib/auto-complete.component.spec.ts
+++ b/projects/auto-complete/src/lib/auto-complete.component.spec.ts
@@ -50,6 +50,14 @@ describe('NguiAutoCompleteComponent', () => {
 		const dropdown: HTMLElement = fixture.nativeElement.querySelector('ul');
 		expect(dropdown.classList.contains('dropup')).toBe(true);
 	});
+
+	it('should update the two-way value() and emit valueSelected when an item is selected', () => {
+		const emitted: any[] = [];
+		component.valueSelected.subscribe((v) => emitted.push(v));
+		component.selectOne('Item 1');
+		expect(component.value()).toBe('Item 1');
+		expect(emitted).toEqual(['Item 1']);
+	});
 });
 
 @Component({

--- a/projects/auto-complete/src/lib/auto-complete.component.ts
+++ b/projects/auto-complete/src/lib/auto-complete.component.ts
@@ -9,6 +9,7 @@ import {
 	ViewEncapsulation,
 	inject,
 	input,
+	model,
 	output,
 	signal,
 	viewChild,
@@ -66,9 +67,11 @@ export class NguiAutoCompleteComponent implements OnInit {
 	// dropdown above the input; `down`/`auto` keep it below.
 	public openDirection = input<'auto' | 'up' | 'down'>('auto', { alias: 'open-direction' });
 
+	// Two-way bindable selected value: `[(value)]="myValue"`.
+	public value = model<any>();
+
 	public valueSelected = output<any>();
 	public customSelected = output<any>();
-	public textEntered = output<any>();
 	public noMatchFound = output<void>();
 
 	public autoCompleteInput = viewChild<ElementRef>('autoCompleteInput');
@@ -226,14 +229,11 @@ export class NguiAutoCompleteComponent implements OnInit {
 
 	public selectOne(data: any) {
 		if (!!data || data === '') {
+			this.value.set(data);
 			this.valueSelected.emit(data);
 		} else {
 			this.customSelected.emit(this.keyword);
 		}
-	}
-
-	public enterText(data: any) {
-		this.textEntered.emit(data);
 	}
 
 	public blurHandler(evt: any) {

--- a/projects/auto-complete/src/lib/auto-complete.directive.spec.ts
+++ b/projects/auto-complete/src/lib/auto-complete.directive.spec.ts
@@ -1,0 +1,46 @@
+import { Component } from '@angular/core';
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { FormsModule } from '@angular/forms';
+
+import { NguiAutoCompleteDirective } from './auto-complete.directive';
+
+@Component({
+	imports: [NguiAutoCompleteDirective, FormsModule],
+	template: `<input ngui-auto-complete [(ngModel)]="value" [source]="source" />`,
+})
+class HostComponent {
+	value = 'init';
+	source = ['Alpha', 'Beta'];
+}
+
+describe('NguiAutoCompleteDirective (ControlValueAccessor)', () => {
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({ imports: [HostComponent] }).compileComponents();
+	});
+
+	it('writes the bound value into the input (writeValue)', fakeAsync(() => {
+		const fixture = TestBed.createComponent(HostComponent);
+		fixture.detectChanges();
+		tick(); // ngModel writes the value asynchronously
+		fixture.detectChanges();
+
+		const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+		expect(input.value).toBe('init');
+		fixture.destroy();
+	}));
+
+	it('propagates a selected value back to the bound model (onChange)', fakeAsync(() => {
+		const fixture = TestBed.createComponent(HostComponent);
+		fixture.detectChanges();
+		tick();
+
+		const directive = fixture.debugElement.query(By.directive(NguiAutoCompleteDirective)).injector.get(NguiAutoCompleteDirective);
+		directive.selectNewValue('Beta');
+		tick();
+		fixture.detectChanges();
+
+		expect(fixture.componentInstance.value).toBe('Beta');
+		fixture.destroy();
+	}));
+});

--- a/projects/auto-complete/src/lib/auto-complete.directive.ts
+++ b/projects/auto-complete/src/lib/auto-complete.directive.ts
@@ -3,12 +3,10 @@ import {
 	booleanAttribute,
 	ComponentRef,
 	Directive,
-	Input,
+	forwardRef,
 	numberAttribute,
-	OnChanges,
 	OnDestroy,
 	OnInit,
-	SimpleChanges,
 	TemplateRef,
 	ViewContainerRef,
 	inject,
@@ -16,16 +14,22 @@ import {
 	output,
 } from '@angular/core';
 import { Subscription } from 'rxjs';
-import { AbstractControl, ControlContainer, FormControl, FormGroup, FormGroupName } from '@angular/forms';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { NguiAutoCompleteComponent } from './auto-complete.component';
 
 @Directive({
 	// eslint-disable-next-line @angular-eslint/directive-selector -- public API selector is kebab-case by design
 	selector: '[ngui-auto-complete]',
+	providers: [
+		{
+			provide: NG_VALUE_ACCESSOR,
+			useExisting: forwardRef(() => NguiAutoCompleteDirective),
+			multi: true,
+		},
+	],
 })
-export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewInit, OnDestroy {
+export class NguiAutoCompleteDirective implements OnInit, AfterViewInit, OnDestroy, ControlValueAccessor {
 	viewContainerRef = inject(ViewContainerRef);
-	private parentForm = inject(ControlContainer, { optional: true, host: true, skipSelf: true });
 
 	public autocomplete = input(false, { transform: booleanAttribute });
 	public autoCompletePlaceholder = input('', { alias: 'auto-complete-placeholder' });
@@ -59,23 +63,15 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
 	public itemTemplate = input<TemplateRef<{ $implicit: any; index: number }> | null>(null);
 	public headerTemplate = input<TemplateRef<void> | null>(null);
 
-	// Value / forms bindings are still classic @Input()s: `ngModel` is reassigned internally
-	// (read-only signal inputs forbid that) and the whole group is slated to be replaced by a
-	// ControlValueAccessor in a later phase.
-	@Input() public ngModel: string;
-	@Input('formControlName') public formControlName: string;
-	// if [formControl] is used on the anchor where our directive is sitting
-	// a form is not necessary to use a formControl we should also support this
-	@Input('formControl') public extFormControl: FormControl;
-
 	public zIndex = input(1, { alias: 'z-index', transform: numberAttribute });
 	public isRtl = input(false, { alias: 'is-rtl', transform: booleanAttribute });
 	// 'down' / 'up' force the dropdown below / above the input; 'auto' (default) opens
 	// below unless the input sits near the bottom of the viewport.
 	public openDirection = input<'auto' | 'up' | 'down'>('auto', { alias: 'open-direction' });
 
-	public ngModelChange = output<any>();
-	public valueChanged = output<any>();
+	// Fired when a custom (not-in-list) value is committed. The value binding is handled by
+	// Angular forms through the ControlValueAccessor below (use `[(ngModel)]`, `[formControl]`
+	// or `formControlName`), so there is no separate value-change output.
 	public customSelected = output<any>();
 	public noMatchFound = output<void>();
 
@@ -84,12 +80,16 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
 	private el: HTMLElement;
 	private acDropdownEl: HTMLElement;
 	private inputEl: HTMLInputElement;
-	private formControl: AbstractControl;
+	private value: any;
 	private revertValue: any;
 	private dropdownJustHidden: boolean;
 	private scheduledBlurHandler: any;
 	private documentClickListener: (e: MouseEvent) => any;
 	private dropdownSubs = new Subscription();
+
+	// ControlValueAccessor callbacks (registered by Angular forms).
+	private onChange: (value: any) => void = () => {};
+	private onTouched: () => void = () => {};
 
 	constructor() {
 		this.el = this.viewContainerRef.element.nativeElement;
@@ -114,31 +114,15 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
 		this.wrapperEl.style.position = 'relative';
 		this.el.parentElement.insertBefore(this.wrapperEl, this.el.nextSibling);
 		this.wrapperEl.appendChild(this.el);
-
-		// Check if we were supplied with a [formControlName] and it is inside a [form]
-		// else check if we are supplied with a [FormControl] regardless if it is inside a [form] tag
-		if (this.parentForm && this.formControlName) {
-			if (this.parentForm['form']) {
-				this.formControl = (this.parentForm['form'] as FormGroup).get(this.formControlName);
-			} else if (this.parentForm instanceof FormGroupName) {
-				this.formControl = (this.parentForm as FormGroupName).control.controls[this.formControlName];
-			}
-		} else if (this.extFormControl) {
-			this.formControl = this.extFormControl;
-		}
-
-		// apply toString() method for the object
-		if (!!this.ngModel) {
-			this.selectNewValue(this.ngModel);
-		} else if (!!this.formControl && this.formControl.value) {
-			this.selectNewValue(this.formControl.value);
-		}
 	}
 
 	ngAfterViewInit() {
 		// if this element is not an input tag, move dropdown after input tag
 		// so that it displays correctly
 		this.inputEl = this.el.tagName === 'INPUT' ? (this.el as HTMLInputElement) : this.el.querySelector('input');
+
+		// Render any value Angular forms wrote before the input element was available.
+		this.renderInputValue(this.value);
 
 		if (this.openOnFocus()) {
 			this.inputEl.addEventListener('focus', (e) => this.showAutoCompleteDropdown(e));
@@ -170,11 +154,30 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
 		}
 	}
 
-	ngOnChanges(changes: SimpleChanges): void {
-		if (changes['ngModel']) {
-			this.ngModel = this.setToStringFunction(changes['ngModel'].currentValue);
-			this.renderValue(this.ngModel);
+	// ----- ControlValueAccessor -----
+
+	writeValue(value: any): void {
+		this.value = value;
+		this.renderInputValue(value);
+	}
+
+	registerOnChange(fn: (value: any) => void): void {
+		this.onChange = fn;
+	}
+
+	registerOnTouched(fn: () => void): void {
+		this.onTouched = fn;
+	}
+
+	setDisabledState(isDisabled: boolean): void {
+		if (this.inputEl) {
+			this.inputEl.disabled = isDisabled;
 		}
+	}
+
+	private renderInputValue(value: any): void {
+		const item = value && typeof value === 'object' ? this.setToStringFunction(value) : value;
+		this.renderValue(item === null || item === undefined ? '' : item);
 	}
 
 	// show auto-complete list below the current element
@@ -217,7 +220,6 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
 		this.dropdownSubs.unsubscribe();
 		this.dropdownSubs = new Subscription();
 		this.dropdownSubs.add(component.valueSelected.subscribe(this.selectNewValue));
-		this.dropdownSubs.add(component.textEntered.subscribe(this.enterNewText));
 		this.dropdownSubs.add(component.customSelected.subscribe(this.selectCustomValue));
 		this.dropdownSubs.add(component.noMatchFound.subscribe(() => this.noMatchFound.emit()));
 
@@ -246,6 +248,7 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
 	public blurHandler(event: any) {
 		if (this.componentRef) {
 			const component = this.componentRef.instance;
+			this.onTouched();
 
 			if (this.selectOnBlur()) {
 				component.selectOne(component.filteredList()[component.itemIndex()]);
@@ -360,15 +363,9 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
 		if (selectValueOf && item !== null && typeof item === 'object') {
 			val = item[selectValueOf];
 		}
-		if ((this.parentForm && this.formControlName) || this.extFormControl) {
-			if (!!val) {
-				this.formControl.patchValue(val);
-			}
-		}
-		if (val !== this.ngModel) {
-			this.ngModelChange.emit(val);
-		}
-		this.valueChanged.emit(val);
+		this.value = val;
+		this.onChange(val);
+		this.onTouched();
 		this.hideAutoCompleteDropdown();
 		setTimeout(() => {
 			if (this.reFocusAfterSelect()) {
@@ -393,8 +390,8 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
 
 	public enterNewText = (value: any) => {
 		this.renderValue(value);
-		this.ngModelChange.emit(value);
-		this.valueChanged.emit(value);
+		this.value = value;
+		this.onChange(value);
 		this.hideAutoCompleteDropdown();
 	};
 

--- a/projects/demo/src/app/component-test/component-test.component.html
+++ b/projects/demo/src/app/component-test/component-test.component.html
@@ -59,11 +59,7 @@
 			<div class="demo-area">
 				<input [(ngModel)]="myModel" (focus)="showMe = true" (blur)="showMe = false" placeholder="click to open dropdown" />
 				@if (showMe) {
-					<ngui-auto-complete
-						[show-dropdown-on-init]="true"
-						(valueSelected)="myModel = $event"
-						[show-input-tag]="false"
-						[source]="[1, 2, 3, 4, 5]">
+					<ngui-auto-complete [show-dropdown-on-init]="true" [(value)]="myModel" [show-input-tag]="false" [source]="[1, 2, 3, 4, 5]">
 					</ngui-auto-complete>
 				}
 			</div>

--- a/projects/demo/src/app/component-test/component-test.component.ts
+++ b/projects/demo/src/app/component-test/component-test.component.ts
@@ -72,7 +72,7 @@ export class ComponentTestComponent {
 @if (showMe) {
   <ngui-auto-complete
     [show-dropdown-on-init]="true"
-    (valueSelected)="myModel = $event"
+    [(value)]="myModel"
     [show-input-tag]="false"
     [source]="[1, 2, 3, 4, 5]">
   </ngui-auto-complete>

--- a/projects/demo/src/app/directive-test/directive-test.component.html
+++ b/projects/demo/src/app/directive-test/directive-test.component.html
@@ -20,10 +20,10 @@
 					[accept-user-input]="true"
 					[auto-select-first-item]="false"
 					[select-on-blur]="true"
+					[ngModel]="model1"
 					(ngModelChange)="myCallback1($event)"
-					(customSelected)="customCallback($event)"
-					placeholder="enter text">
-					<input id="model1" [ngModel]="model1" autofocus />
+					(customSelected)="customCallback($event)">
+					<input id="model1" autofocus placeholder="enter text" />
 				</div>
 			</div>
 			<p class="model-display">
@@ -53,10 +53,10 @@
 					[open-on-focus]="false"
 					[auto-select-first-item]="false"
 					[select-on-blur]="true"
+					[ngModel]="model1"
 					(ngModelChange)="myCallback1($event)"
-					(customSelected)="customCallback($event)"
-					placeholder="enter text">
-					<input id="model1-1" [ngModel]="model1" autofocus />
+					(customSelected)="customCallback($event)">
+					<input id="model1-1" autofocus placeholder="enter text" />
 				</div>
 			</div>
 			<p class="model-display">
@@ -248,9 +248,9 @@
 					ngui-auto-complete
 					[source]="arrayOfStrings"
 					[auto-select-first-item]="true"
-					(ngModelChange)="myCallback7($event)"
-					placeholder="enter text">
-					<input id="model7" [ngModel]="model7" />
+					[ngModel]="model7"
+					(ngModelChange)="myCallback7($event)">
+					<input id="model7" placeholder="enter text" />
 				</div>
 			</div>
 			<p class="model-display">
@@ -280,10 +280,10 @@
 					ngui-auto-complete
 					[source]="arrayOfArabicStrings"
 					[accept-user-input]="false"
-					(ngModelChange)="myCallback8($event)"
 					[is-rtl]="true"
-					placeholder="ابحث عن مدينة...">
-					<input id="model8" [ngModel]="model8" />
+					[ngModel]="model8"
+					(ngModelChange)="myCallback8($event)">
+					<input id="model8" placeholder="ابحث عن مدينة..." />
 				</div>
 			</div>
 			<p class="model-display">
@@ -422,10 +422,10 @@
 					[accept-user-input]="true"
 					[auto-select-first-item]="false"
 					[select-on-blur]="true"
+					[ngModel]="model10"
 					(ngModelChange)="myCallback10($event)"
-					(customSelected)="customCallback($event)"
-					placeholder="try: Cad or Mun">
-					<input id="model10" [ngModel]="model10" autofocus />
+					(customSelected)="customCallback($event)">
+					<input id="model10" autofocus placeholder="try: Cad or Mun" />
 				</div>
 			</div>
 			<p class="model-display">
@@ -464,9 +464,10 @@
 					[open-direction]="openDir"
 					[accept-user-input]="true"
 					[select-on-blur]="true"
+					[ngModel]="model13"
 					(ngModelChange)="myCallback1($event)"
 					(customSelected)="customCallback($event)">
-					<input id="model13" [ngModel]="model13" placeholder="opens {{ openDir }}" />
+					<input id="model13" placeholder="opens {{ openDir }}" />
 				</div>
 			</div>
 			<p class="model-display">

--- a/projects/demo/src/app/directive-test/directive-test.component.ts
+++ b/projects/demo/src/app/directive-test/directive-test.component.ts
@@ -123,10 +123,10 @@ export class DirectiveTestComponent {
        [accept-user-input]="true"
        [auto-select-first-item]="false"
        [select-on-blur]="true"
+       [ngModel]="model1"
        (ngModelChange)="myCallback1($event)"
-       (customSelected)="customCallback($event)"
-       placeholder="enter text">
-    <input id="model1" [ngModel]="model1" autofocus />
+       (customSelected)="customCallback($event)">
+    <input id="model1" autofocus placeholder="enter text" />
   </div>
   `;
 
@@ -137,10 +137,10 @@ export class DirectiveTestComponent {
        [open-on-focus]="false"
        [auto-select-first-item]="false"
        [select-on-blur]="true"
+       [ngModel]="model1"
        (ngModelChange)="myCallback1($event)"
-       (customSelected)="customCallback($event)"
-       placeholder="enter text">
-    <input id="model1-1" [ngModel]="model1" autofocus />
+       (customSelected)="customCallback($event)">
+    <input id="model1-1" autofocus placeholder="enter text" />
   </div>
   `;
 
@@ -210,9 +210,9 @@ export class DirectiveTestComponent {
   <div ngui-auto-complete
        [source]="arrayOfStrings"
        [auto-select-first-item]="true"
-       (ngModelChange)="myCallback7($event)"
-       placeholder="enter text">
-    <input id="model7" [ngModel]="model7"/>
+       [ngModel]="model7"
+       (ngModelChange)="myCallback7($event)">
+    <input id="model7" placeholder="enter text"/>
   </div>
   `;
 
@@ -220,10 +220,10 @@ export class DirectiveTestComponent {
   <div ngui-auto-complete
         [source]="arrayOfStrings"
         [accept-user-input]="false"
-        (ngModelChange)="myCallback8($event)"
         [is-rtl]="true"
-        placeholder="enter text">
-        <input id="model8" [ngModel]="model8" autofocus />
+        [ngModel]="model8"
+        (ngModelChange)="myCallback8($event)">
+        <input id="model8" autofocus placeholder="enter text" />
       </div>
   `;
 
@@ -244,10 +244,10 @@ export class DirectiveTestComponent {
        [accept-user-input]="true"
        [auto-select-first-item]="false"
        [select-on-blur]="true"
+       [ngModel]="model10"
        (ngModelChange)="myCallback10($event)"
-       (customSelected)="customCallback($event)"
-       placeholder="enter text">
-        <input id="model10" [ngModel]="model10" autofocus />
+       (customSelected)="customCallback($event)">
+        <input id="model10" autofocus placeholder="try: Cad or Mun" />
     </div>
   `;
 
@@ -291,8 +291,13 @@ export class DirectiveTestComponent {
 
   <div ngui-auto-complete
        [source]="arrayOfStrings"
-       [open-direction]="openDir">
-    <input [ngModel]="model13" placeholder="opens {{ openDir }}" />
+       [open-direction]="openDir"
+       [accept-user-input]="true"
+       [select-on-blur]="true"
+       [ngModel]="model13"
+       (ngModelChange)="myCallback1($event)"
+       (customSelected)="customCallback($event)">
+    <input id="model13" placeholder="opens {{ openDir }}" />
   </div>
   `;
 


### PR DESCRIPTION
## Summary

Phase C of the post-Angular-21 modernization (the headline one): replace the directive's hand-rolled value/forms wiring with a proper **`ControlValueAccessor`**, and add a two-way **`[(value)]`** model to the component. Folds into the unpublished `21.0.0`.

## Area

- [x] 📦 Library (`projects/auto-complete`)
- [x] 🎨 Demo app (`projects/demo`)
- [x] 📝 Docs

## Changes

- **Directive → `ControlValueAccessor`** (`NG_VALUE_ACCESSOR`): `writeValue` / `registerOnChange` / `registerOnTouched` / `setDisabledState`. Selection & free-text entry call `onChange`/`onTouched`. Dropped `ngOnChanges` and the manual `ControlContainer`/`FormControl` resolution.
- **Component**: added `value = model<any>()` for `[(value)]` (set on selection); removed the never-emitted `textEntered` output + `enterText()`.
- **Demo**: wrapper-`<div>` examples bind `[ngModel]` on the host; the component focus demo showcases `[(value)]`. Direct-`[(ngModel)]` examples unchanged.
- **Tests**: component value-model test + a new directive CVA spec (`writeValue` render + `onChange` via `[(ngModel)]`).
- **Docs**: CHANGELOG breaking entries, README forms + reactive-forms sections and API tables, new `MIGRATION.md` (shipped with the package).

## Impact (⚠️ breaking)

- Removed the directive's bespoke `ngModel` input and its `(ngModelChange)` / `(valueChanged)` outputs, and its custom `[formControl]` / `formControlName` inputs — these now flow through Angular forms.
  - `[(ngModel)]` on an input is **unchanged** and still emits `(ngModelChange)`.
  - `[formControl]` / `formControlName` now work via the standard directives (same syntax, full integration: `valueChanges`, `touched`/`dirty`).
  - **Wrapper-`<div>`**: bind the value on the host — `<div ngui-auto-complete [(ngModel)]="x"><input></div>`.
  - `(valueChanged)` → use `(ngModelChange)` or the control's `valueChanges`.
- Removed the dead `(textEntered)` component output.

Full before/after in [`MIGRATION.md`](https://github.com/ng2-ui/auto-complete/blob/master/MIGRATION.md).

## How to test

```bash
npm run build-lib:prod
npm run build-docs
npm run lint
npx ng test auto-complete --watch=false --browsers=ChromeHeadless
npx ng test demo --watch=false --browsers=ChromeHeadless
npm run format:check
```

Manual: in the demo, exercise both `[(ngModel)]` (direct input + wrapper div), the component `[(value)]` focus demo, and the custom-template / no-match cards.

## Checklist

- [x] Scope is small and single-concern
- [x] Conventional Commit title
- [x] `build-lib:prod`, `build-docs`, `lint`, unit tests (lib 12/12 + demo 5/5) and `format:check` all pass
- [x] **CHANGELOG.md** updated (21.0.0 entry)
- [x] **README.md** updated (forms + API tables)
- [x] Breaking changes documented — CHANGELOG + new **MIGRATION.md**, title marked `!` / `BREAKING CHANGE:`
- [x] No generated `build-info.ts` timestamp committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
