### PR TITLE
refactor(demo): inline styles → SCSS + logical CSS; fix(lib): logical drop-up anchor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ and this project follows [Angular version numbers](https://angular.dev/reference
   is signal-based, so remote/async results and directive-driven updates refresh reliably with less change
   detection work. No public API change.
 - Bumped the library's own `tslib` dependency floor to `^2.8.1`.
+- The "drop-up" dropdown now anchors with the logical `inset-inline-start` instead of `left`, so it sits
+  on the correct edge under RTL (matching the directive's positioning). No API change.
 
 ### Internal (development tooling only — no impact on consumers)
 - `ng update` to Angular 21: `@angular/cli` + `@angular-devkit/build-angular` 21.2.x,

--- a/projects/auto-complete/src/lib/auto-complete.component.scss
+++ b/projects/auto-complete/src/lib/auto-complete.component.scss
@@ -39,7 +39,9 @@
 .ngui-auto-complete > ul.dropup {
 	position: absolute;
 	bottom: 100%;
-	left: 0;
+	// Logical inline-start anchors LTR→left / RTL→right automatically (matches the
+	// directive's inset-inline-start positioning), so RTL needs no override.
+	inset-inline-start: 0;
 }
 
 .ngui-auto-complete > ul li {

--- a/projects/demo/src/app/component-test/component-test.component.html
+++ b/projects/demo/src/app/component-test/component-test.component.html
@@ -36,7 +36,7 @@
 							no-match-found-text="No Match Found"
 							placeholder="Enter a place name (min. 2 chars)">
 						</ngui-auto-complete>
-						<ng-template #loadingTpl><span style="padding: 8px; color: #888">Searching…</span></ng-template>
+						<ng-template #loadingTpl><span class="loading-hint">Searching…</span></ng-template>
 					}
 				</div>
 			</div>

--- a/projects/demo/src/app/component-test/component-test.component.scss
+++ b/projects/demo/src/app/component-test/component-test.component.scss
@@ -19,3 +19,9 @@ input:not([mat-input]) {
 		box-shadow: 0 0 0 2px rgba(63, 81, 181, 0.15);
 	}
 }
+
+// Loading row shown via [loadingTemplate]
+.loading-hint {
+	padding: 8px;
+	color: #888;
+}

--- a/projects/demo/src/app/directive-test/directive-test.component.html
+++ b/projects/demo/src/app/directive-test/directive-test.component.html
@@ -209,7 +209,7 @@
 			</mat-card-subtitle>
 		</mat-card-header>
 		<mat-card-content>
-			<div class="demo-area">
+			<div class="demo-area material-demo">
 				<mat-form-field appearance="outline">
 					<mat-icon fontIcon="attach_money" matPrefix></mat-icon>
 					<input
@@ -219,7 +219,6 @@
 						[(ngModel)]="amount"
 						[source]="arrayOfNumbers"
 						[list-formatter]="rightAligned"
-						z-index="10"
 						placeholder="amount" />
 					<span matSuffix>.00</span>
 				</mat-form-field>

--- a/projects/demo/src/app/directive-test/directive-test.component.html
+++ b/projects/demo/src/app/directive-test/directive-test.component.html
@@ -210,7 +210,7 @@
 		</mat-card-header>
 		<mat-card-content>
 			<div class="demo-area">
-				<mat-form-field appearance="outline" style="width: 100%">
+				<mat-form-field appearance="outline">
 					<mat-icon fontIcon="attach_money" matPrefix></mat-icon>
 					<input
 						matInput
@@ -219,6 +219,7 @@
 						[(ngModel)]="amount"
 						[source]="arrayOfNumbers"
 						[list-formatter]="rightAligned"
+						z-index="10"
 						placeholder="amount" />
 					<span matSuffix>.00</span>
 				</mat-form-field>
@@ -273,7 +274,7 @@
 			</mat-card-subtitle>
 		</mat-card-header>
 		<mat-card-content>
-			<div class="demo-area" dir="rtl" style="text-align: right">
+			<div class="demo-area rtl-demo" dir="rtl">
 				<div
 					ngui-auto-complete
 					[source]="arrayOfArabicStrings"
@@ -307,7 +308,6 @@
 			<div class="demo-area">
 				<input
 					ngui-auto-complete
-					style="width: 100%"
 					name="city"
 					[(ngModel)]="city"
 					[source]="arrayOfCities"

--- a/projects/demo/src/app/directive-test/directive-test.component.scss
+++ b/projects/demo/src/app/directive-test/directive-test.component.scss
@@ -26,6 +26,13 @@ input:not([mat-input]):not([type='checkbox']) {
 	width: 100%;
 }
 
+// Right-align the amount input so the selected value lines up with the right-aligned
+// dropdown rows (.amount-cell). (Dropdown stacking inside mat-form-field is handled by
+// the CDK Overlay migration, not here.)
+.material-demo .mat-mdc-input-element {
+	text-align: end;
+}
+
 // RTL card: align inline content to the reading direction (logical: start === right under dir="rtl").
 .rtl-demo {
 	text-align: start;

--- a/projects/demo/src/app/directive-test/directive-test.component.scss
+++ b/projects/demo/src/app/directive-test/directive-test.component.scss
@@ -21,6 +21,16 @@ input:not([mat-input]):not([type='checkbox']) {
 	}
 }
 
+// Material Integration card: let the form field fill the demo area.
+.demo-area mat-form-field {
+	width: 100%;
+}
+
+// RTL card: align inline content to the reading direction (logical: start === right under dir="rtl").
+.rtl-demo {
+	text-align: start;
+}
+
 // Limit max-height on the first two string examples
 .demo-1 .ngui-auto-complete > ul {
 	max-height: 120px;

--- a/projects/demo/src/app/directive-test/directive-test.component.ts
+++ b/projects/demo/src/app/directive-test/directive-test.component.ts
@@ -188,6 +188,7 @@ export class DirectiveTestComponent {
              [(ngModel)]="amount"
              [source]="arrayOfNumbers"
              [list-formatter]="rightAligned"
+             z-index="10"
              placeholder="amount"/>
       <span matSuffix>.00</span>
    </mat-form-field>
@@ -304,8 +305,8 @@ export class DirectiveTestComponent {
 
 	public renderBook(data: any): string {
 		const author = data.author_name?.length ? data.author_name[0] : 'Unknown author';
-		return `<b style="display:block">${data.title}</b>
-            <small style="color:#888">${author}</small>`;
+		return `<b class="book-title">${data.title}</b>
+            <small class="book-author">${author}</small>`;
 	}
 
 	public renderCity(data: any): string {
@@ -321,7 +322,7 @@ export class DirectiveTestComponent {
 	}
 
 	public rightAligned(data: any): string {
-		return `<div style="text-align:right">${data}.00</div>`;
+		return `<div class="amount-cell">${data}.00</div>`;
 	}
 
 	public json(obj) {

--- a/projects/demo/src/app/directive-test/directive-test.component.ts
+++ b/projects/demo/src/app/directive-test/directive-test.component.ts
@@ -188,7 +188,6 @@ export class DirectiveTestComponent {
              [(ngModel)]="amount"
              [source]="arrayOfNumbers"
              [list-formatter]="rightAligned"
-             z-index="10"
              placeholder="amount"/>
       <span matSuffix>.00</span>
    </mat-form-field>
@@ -322,7 +321,9 @@ export class DirectiveTestComponent {
 	}
 
 	public rightAligned(data: any): string {
-		return `<div class="amount-cell">${data}.00</div>`;
+		// The field shows "$" (prefix) and ".00" (suffix), so the row only needs the bare,
+		// right-aligned number — matching what lands in the input after selection.
+		return `<div class="amount-cell">${data}</div>`;
 	}
 
 	public json(obj) {

--- a/projects/demo/src/styles.scss
+++ b/projects/demo/src/styles.scss
@@ -209,6 +209,21 @@ body {
 	}
 }
 
+// Dropdown row content produced by `list-formatter` strings. These are rendered into the
+// library dropdown via [innerHtml], so they live outside any component's style scope and
+// must be styled globally.
+.amount-cell {
+	text-align: end;
+}
+
+.book-title {
+	display: block;
+}
+
+.book-author {
+	color: #888;
+}
+
 // Component test specific
 .addr-chip {
 	display: inline-flex;


### PR DESCRIPTION
## Area

Demo styling + a small library RTL CSS fix (groundwork before Phase Overlay). Part of the v21.0.0 series.

## What changed

**Library**
- `.dropup` dropdown anchored with a physical `left: 0`, so under RTL it sat on the wrong edge. Now uses the logical `inset-inline-start: 0`, matching the directive's positioning. No API change.

**Demo**
- Moved template inline styles into SCSS: `mat-form-field` width, the RTL card's text alignment (now logical `text-align: start`), and dropped a redundant `width:100%` on the city input (already covered by a global rule).
- Moved `list-formatter`-generated inline styles to global classes (`.amount-cell`, `.book-title`, `.book-author`) — they render into the library dropdown via `[innerHtml]`, so they can't be component-scoped — and the loading `<span>` to `.loading-hint`.
- Logical CSS: the amount cell now uses `text-align: end` instead of `right`.
- **Cleaned up the confusing "Angular Material Integration" card:** right-aligned the amount input so the selected value lines up with the right-aligned dropdown rows, and dropped the `.00` the rows appended (the field already has a `$` prefix and `.00` suffix, so rows + committed value now show the bare number consistently).

## Stacking (deferred)

The amount dropdown is painted behind the "View Template" expansion panel because `mat-form-field` traps the stacking context — an input-level `z-index` can't escape it. Rather than hack the demo, this is **deferred to Phase Overlay** (next PR): rendering the dropdown in a CDK overlay at the document root fixes it universally.

## Validation

`build-lib:prod` · `build-docs` · `lint` · `ng test auto-complete` (14/14) · `ng test demo` (5/5) · `format:check` — all green.

## Notes

- Not merging from my side — please review and merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
