### PR TITLE
fix(lib): unique id on internal keyword input (a11y, form-safe)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,12 @@ and this project follows [Angular version numbers](https://angular.dev/reference
 - The "drop-up" dropdown now anchors with the logical `inset-inline-start` instead of `left`, so it sits
   on the correct edge under RTL (matching the directive's positioning). No API change.
 
+### Fixed
+- **Internal keyword input a11y.** The component's internal input (rendered when `show-input-tag`) now
+  carries a unique `id`, clearing the browser's "a form field element should have an id or name" warning.
+  It is bound `standalone`, so it never registers into a consumer's parent `<form>` (no stray
+  `keyword` control) — which also fixes a latent error when the component was used inside a `<form>`.
+
 ### Internal (development tooling only — no impact on consumers)
 - `ng update` to Angular 21: `@angular/cli` + `@angular-devkit/build-angular` 21.2.x,
   `ng-packagr` 21.2.5, TypeScript 5.9.3. The demo `bootstrapApplication` now provides

--- a/projects/auto-complete/src/lib/auto-complete.component.html
+++ b/projects/auto-complete/src/lib/auto-complete.component.html
@@ -4,12 +4,14 @@
 		<input
 			#autoCompleteInput
 			class="keyword"
+			[id]="inputId"
 			[attr.autocomplete]="autocomplete() ? 'null' : 'off'"
 			placeholder="{{ placeholder() }}"
 			(focus)="showDropdownList($event)"
 			(blur)="blurHandler($event)"
 			(keydown)="inputElKeyHandler($event)"
 			(input)="reloadListInDelay($event)"
+			[ngModelOptions]="{ standalone: true }"
 			[(ngModel)]="keyword" />
 	}
 

--- a/projects/auto-complete/src/lib/auto-complete.component.spec.ts
+++ b/projects/auto-complete/src/lib/auto-complete.component.spec.ts
@@ -35,6 +35,13 @@ describe('NguiAutoCompleteComponent', () => {
 		expect(component.acceptUserInput()).toBe(true);
 	});
 
+	it('should give the internal keyword input a unique id and no name attribute (a11y, form-safe)', () => {
+		const input: HTMLInputElement = fixture.nativeElement.querySelector('input.keyword');
+		expect(input.id).toBe(component.inputId);
+		expect(input.id).toMatch(/^ngui-auto-complete-input-\d+$/);
+		expect(input.hasAttribute('name')).toBe(false);
+	});
+
 	it('should default open-direction to "auto" and not mark the dropdown as dropup', () => {
 		component.dropdownVisible.set(true);
 		fixture.detectChanges();

--- a/projects/auto-complete/src/lib/auto-complete.component.ts
+++ b/projects/auto-complete/src/lib/auto-complete.component.ts
@@ -31,6 +31,9 @@ export interface NguiAutoCompleteSelection<T = any> {
 import { FormsModule } from '@angular/forms';
 import { NgClass, NgTemplateOutlet } from '@angular/common';
 
+// Per-instance counter for a unique id on the internal keyword input (see `inputId`).
+let nextUniqueId = 0;
+
 @Component({
 	selector: 'ngui-auto-complete',
 	templateUrl: './auto-complete.component.html',
@@ -98,6 +101,11 @@ export class NguiAutoCompleteComponent<T = any> implements OnInit {
 	public minCharsEntered = signal(false);
 	public itemIndex = signal<number | null>(null);
 	public keyword: string;
+
+	// Unique id for the internal keyword input so it satisfies the "form field should have an
+	// id or name" a11y check without a `name` (a named control would register the keyword field
+	// into a consumer's parent form — the input is kept `standalone` for the same reason).
+	public readonly inputId = `ngui-auto-complete-input-${nextUniqueId++}`;
 
 	private el: HTMLElement; // this component  element `<ngui-auto-complete>`
 	private timer = 0;


### PR DESCRIPTION
## Area

Library — accessibility / forms correctness. Part of the v21.0.0 series.

## Problem

The component's internal `<input>` (rendered when `show-input-tag`, e.g. the multi-select component demo) had no `id` or `name`, so Chrome logs **"A form field element should have an id or name attribute."** Naively adding a `name` is wrong: a named `ngModel` would register the internal **keyword** field into a consumer's parent `<form>`, polluting it. The `keyword` input also had no `name` and wasn't `standalone`, so dropping `<ngui-auto-complete show-input-tag>` inside a `<form>` threw the Angular "name attribute must be set or standalone" error.

## Fix

- Add a per-instance unique **`id`** (`inputId = ngui-auto-complete-input-N`) — satisfies the a11y check.
- Bind the keyword `[(ngModel)]` with **`{ standalone: true }`** — keeps it out of any parent form (no stray `keyword` control) and fixes the latent in-`<form>` error.
- No `name` (intentional — see above).

## Validation

`build-lib:prod` · `build-docs` · `lint` · `ng test auto-complete` (15/15, +1 new) · `ng test demo` (5/5) · `format:check` — all green.

## Notes

- Not merging from my side — please review and merge.
- Independent of the Overlay / `source.required` PRs; only CHANGELOG overlaps (trivial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
