### PR TITLE
feat(lib)!: make source a required input (proposal)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ and this project follows [Angular version numbers](https://angular.dev/reference
   `header-item-template` inputs are removed. Use the `headerTemplate` `TemplateRef` (already available) and
   the new `loadingTemplate` `TemplateRef` (`loading-text` remains for the simple case). This also removes
   an `innerHTML` sink.
+- **`source` is now a required input.** `source` uses `input.required` on both the component and directive
+  (it was always required in practice — the control does nothing without it). Omitting `[source]` is now a
+  compile-time error under strict templates (and a runtime error otherwise) instead of silently doing
+  nothing. Just ensure every `[ngui-auto-complete]` / `<ngui-auto-complete>` has a `[source]`.
 
 ### Added
 - **`[(value)]` two-way binding on `NguiAutoCompleteComponent`.** The standalone component now exposes a

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -136,6 +136,17 @@ The standalone component gained a two-way `value` model. `(valueSelected)` still
 <ngui-auto-complete [source]="myArray" [show-input-tag]="false" [(value)]="myValue"></ngui-auto-complete>
 ```
 
+### `source` is now required
+
+`source` is declared with `input.required` on both the directive and component. It was always required in
+practice, but omitting it used to fail silently; now it is a compile-time error (strict templates) or a
+runtime error. The fix is simply to provide `[source]` everywhere — no change is needed if you already do.
+
+```diff
+- <input ngui-auto-complete [(ngModel)]="v" />
++ <input ngui-auto-complete [(ngModel)]="v" [source]="mySource" />
+```
+
 ### Note: signal-based inputs (only affects programmatic access)
 
 All inputs are now signal `input()`s. Template bindings and their names/aliases are unchanged. Only code

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Where suggestions come from and how the keyword is matched.
 
 | Option | Type | Default | Applies to | Description |
 |--------|------|---------|------------|-------------|
-| `source` | `T[] \| string \| ((keyword) => Observable<T[]>)` | — | Both | **Required.** Local array, URL string, or a function returning an `Observable` |
+| `source` | `T[] \| string \| ((keyword) => Observable<T[]>)` | — | Both | **Required** (`input.required` — omitting `[source]` is a compile-time error). Local array, URL string, or a function returning an `Observable` |
 | `path-to-data` | `string` | — | Both | Dot-path to the array in an HTTP response, e.g. `data.results` |
 | `min-chars` | `number` | `0` | Both | Minimum characters before fetching/filtering |
 | `max-num-list` | `number` | unlimited | Both | Maximum number of suggestions to show |

--- a/projects/auto-complete/src/lib/auto-complete.component.ts
+++ b/projects/auto-complete/src/lib/auto-complete.component.ts
@@ -52,8 +52,9 @@ export class NguiAutoCompleteComponent<T = any> implements OnInit {
 	public autocomplete = input(false, { transform: booleanAttribute });
 	public listFormatter = input<((arg: T) => string) | undefined>(undefined, { alias: 'list-formatter' });
 	// Local array, remote URL string, or a function returning an `Observable` of items.
-	// Binding a typed array/function (e.g. `[source]="cities"`) lets Angular infer `T`.
-	public source = input<T[] | string | ((keyword: string) => Observable<T[]>) | undefined>(undefined);
+	// Required — the component does nothing without it. Binding a typed array/function
+	// (e.g. `[source]="cities"`) lets Angular infer `T`.
+	public source = input.required<T[] | string | ((keyword: string) => Observable<T[]>)>();
 	public pathToData = input('', { alias: 'path-to-data' });
 	public minChars = input(0, { alias: 'min-chars', transform: numberAttribute });
 	public placeholder = input('');

--- a/projects/auto-complete/src/lib/auto-complete.directive.ts
+++ b/projects/auto-complete/src/lib/auto-complete.directive.ts
@@ -33,7 +33,8 @@ export class NguiAutoCompleteDirective implements OnInit, AfterViewInit, OnDestr
 
 	public autocomplete = input(false, { transform: booleanAttribute });
 	public autoCompletePlaceholder = input('', { alias: 'auto-complete-placeholder' });
-	public source = input<any>();
+	// Required — array, URL string, or a function returning an `Observable`.
+	public source = input.required<any>();
 	public pathToData = input('', { alias: 'path-to-data' });
 	public minChars = input(0, { alias: 'min-chars', transform: numberAttribute });
 	// Controls the text shown in the input after selecting an object: a property name


### PR DESCRIPTION
## Area

Library — input typing. **Proposal** (part of the v21.0.0 series) — happy to drop this one if you'd rather keep `source` optional.

## What & why

`source` is the one input the control can't work without, yet it was declared optional, so omitting `[source]` failed silently (empty/no dropdown, no hint). This makes it **`input.required`** on both the directive and component:

```diff
- public source = input<any>();                                   // directive
+ public source = input.required<any>();
- public source = input<T[] | string | (...) | undefined>(undefined);  // component
+ public source = input.required<T[] | string | (...)>();
```

Now omitting `[source]` is a **compile-time error** under strict templates (runtime error otherwise) — the mistake surfaces immediately instead of silently doing nothing. The component type also drops the `| undefined` it only carried to model the optional default. No internal logic changes.

## Is this breaking?

Technically yes (`!` / `BREAKING CHANGE`), but only for code that *omitted* `[source]` — which never did anything useful. Anything already binding `[source]` is unaffected. Documented in CHANGELOG + MIGRATION.

## Alternatives considered

- **Keep optional** (status quo) — silent no-op on misuse.
- **Runtime guard/`console.warn`** if missing — softer, but noisier and not type-safe.
- **`input.required`** (this PR) — compile-time safety, zero runtime cost, idiomatic for Angular 17+. Recommended.

## Validation

`build-lib:prod` · `build-docs` · `lint` · `ng test auto-complete` (14/14) · `ng test demo` (5/5) · `format:check` — all green.

## Notes

- Not merging from my side — please review (or reject — it's a proposal).
- Overlaps `auto-complete.directive.ts` + CHANGELOG/README/MIGRATION with the upcoming Overlay PR; I'll rebase whichever merges second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
