### PR TITLE
feat(lib)!: render the directive dropdown via CDK Overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,11 @@ and this project follows [Angular version numbers](https://angular.dev/reference
   `overflow: hidden`) and flips above/below automatically on overflow. As a result, `open-direction` is now
   a *preference* (the overlay still flips when there isn't room), and `z-index` is rarely needed (the
   overlay already layers above page content; it now only orders overlapping overlays). RTL follows the
-  input's computed direction.
+  input's computed direction. **Note:** because the dropdown is at the document root, custom dropdown
+  styles (e.g. classes from a `list-formatter`) must be global, not scoped to an ancestor of the input.
+- **Refreshed dropdown styling.** The dropdown now has a subtle elevation, rounded corners, a softer
+  border and roomier rows, and a default height cap via the overridable `--ngui-ac-max-height` CSS variable
+  (default `256px`; set `--ngui-ac-max-height: none` to remove it). Applies to the directive and component.
 
 ### Fixed
 - **Internal keyword input a11y.** The component's internal input (rendered when `show-input-tag`) now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,9 +94,12 @@ and this project follows [Angular version numbers](https://angular.dev/reference
   overlay already layers above page content; it now only orders overlapping overlays). RTL follows the
   input's computed direction. **Note:** because the dropdown is at the document root, custom dropdown
   styles (e.g. classes from a `list-formatter`) must be global, not scoped to an ancestor of the input.
-- **Refreshed dropdown styling.** The dropdown now has a subtle elevation, rounded corners, a softer
-  border and roomier rows, and a default height cap via the overridable `--ngui-ac-max-height` CSS variable
-  (default `256px`; set `--ngui-ac-max-height: none` to remove it). Applies to the directive and component.
+- **Refreshed, themeable dropdown styling.** The dropdown now has a subtle elevation, rounded corners, a
+  softer border and roomier rows. Appearance is exposed through CSS variables — `--ngui-ac-background`,
+  `--ngui-ac-color`, `--ngui-ac-border`, `--ngui-ac-border-radius`, `--ngui-ac-shadow`,
+  `--ngui-ac-max-height` (`none` to remove the cap), `--ngui-ac-item-border`, `--ngui-ac-hover-background`
+  and `--ngui-ac-selected-background` — each with a sensible default (set them on `:root`). See the
+  README "Theming" section. Applies to the directive and component.
 
 ### Fixed
 - **Internal keyword input a11y.** The component's internal input (rendered when `show-input-tag`) now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,8 +97,9 @@ and this project follows [Angular version numbers](https://angular.dev/reference
 - **Refreshed, themeable dropdown styling.** The dropdown now has a subtle elevation, rounded corners, a
   softer border and roomier rows. Appearance is exposed through CSS variables — `--ngui-ac-background`,
   `--ngui-ac-color`, `--ngui-ac-border`, `--ngui-ac-border-radius`, `--ngui-ac-shadow`,
-  `--ngui-ac-max-height` (`none` to remove the cap), `--ngui-ac-item-border`, `--ngui-ac-hover-background`
-  and `--ngui-ac-selected-background` — each with a sensible default (set them on `:root`). See the
+  `--ngui-ac-max-height` (`none` to remove the cap), `--ngui-ac-item-padding`, `--ngui-ac-item-border`,
+  `--ngui-ac-hover-background` and `--ngui-ac-selected-background` — each with a sensible default (set them
+  on `:root`). See the
   README "Theming" section. Applies to the directive and component.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,11 @@ and this project follows [Angular version numbers](https://angular.dev/reference
   (it was always required in practice — the control does nothing without it). Omitting `[source]` is now a
   compile-time error under strict templates (and a runtime error otherwise) instead of silently doing
   nothing. Just ensure every `[ngui-auto-complete]` / `<ngui-auto-complete>` has a `[source]`.
+- **New `@angular/cdk` peer dependency (directive dropdown now uses the CDK Overlay).** The
+  `[ngui-auto-complete]` directive renders its dropdown through `@angular/cdk/overlay` instead of inserting
+  an absolutely-positioned element next to the input. You must install `@angular/cdk@^21` and include the
+  CDK overlay styles **once** in your app — either `@import '@angular/cdk/overlay-prebuilt.css';` or any
+  `@angular/material` theme (which already bundles them). See [`MIGRATION.md`](./MIGRATION.md).
 
 ### Added
 - **`[(value)]` two-way binding on `NguiAutoCompleteComponent`.** The standalone component now exposes a
@@ -82,6 +87,12 @@ and this project follows [Angular version numbers](https://angular.dev/reference
 - Bumped the library's own `tslib` dependency floor to `^2.8.1`.
 - The "drop-up" dropdown now anchors with the logical `inset-inline-start` instead of `left`, so it sits
   on the correct edge under RTL (matching the directive's positioning). No API change.
+- **CDK Overlay positioning (directive).** The dropdown now renders in a CDK overlay at the document root,
+  so it escapes ancestor clipping / stacking contexts (e.g. inside a `mat-form-field` or a card with
+  `overflow: hidden`) and flips above/below automatically on overflow. As a result, `open-direction` is now
+  a *preference* (the overlay still flips when there isn't room), and `z-index` is rarely needed (the
+  overlay already layers above page content; it now only orders overlapping overlays). RTL follows the
+  input's computed direction.
 
 ### Fixed
 - **Internal keyword input a11y.** The component's internal input (rendered when `show-input-tag`) now

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -11,6 +11,24 @@ tracks the supported Angular major (`@ngui/auto-complete@N` ⇒ Angular `N`).
 
 Update Angular to 21 first. Angular 20 and older projects must stay on `@ngui/auto-complete@20`.
 
+### New `@angular/cdk` peer dependency + CDK overlay styles
+
+The directive now positions its dropdown with the CDK Overlay, so install `@angular/cdk` and include the
+CDK overlay styles **once** in your global stylesheet. If you already use Angular Material's theme, the
+overlay styles are bundled and you only need the package.
+
+```bash
+npm install @angular/cdk
+```
+
+```scss
+/* styles.scss — only if you are NOT importing an Angular Material theme */
+@import '@angular/cdk/overlay-prebuilt.css';
+```
+
+Without these styles the dropdown still works but won't be positioned. In return, the dropdown now escapes
+ancestor clipping/stacking (e.g. inside a `mat-form-field`) and flips on overflow on its own.
+
 ### `NguiAutoCompleteModule` was removed
 
 Import the standalone component/directive directly.

--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ variables on an ancestor of the input won't reach it.
 | `--ngui-ac-border-radius` | `4px` | Corner radius |
 | `--ngui-ac-shadow` | `0 4px 12px rgba(0,0,0,.15)` | Elevation shadow |
 | `--ngui-ac-max-height` | `256px` | Height cap (`none` to remove) |
+| `--ngui-ac-item-padding` | `6px 12px` | Row padding (density) |
 | `--ngui-ac-item-border` | `1px solid rgba(0,0,0,.06)` | Row divider |
 | `--ngui-ac-hover-background` | `rgba(0,0,0,.06)` | Row hover background |
 | `--ngui-ac-selected-background` | `rgba(0,0,0,.1)` | Highlighted row background |

--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ The directive positions its dropdown with the [CDK Overlay](https://material.ang
 
 > **Styling the dropdown:** because the directive renders its dropdown in an overlay at the document root,
 > any custom dropdown styles (e.g. classes used by a `list-formatter` or template) must be **global**, not
-> scoped to an ancestor of the input. The dropdown's height is capped by `--ngui-ac-max-height` (default
-> `256px`) — set it on `:root` to change it, or `--ngui-ac-max-height: none` to remove the cap.
+> scoped to an ancestor of the input. See [Theming](#theming) to restyle it with CSS variables.
 
 ## Setup
 
@@ -264,6 +263,37 @@ onPick(e: NguiAutoCompleteSelection<City>) { /* e.item is City */ }
 It defaults to `any`, so existing templates are unaffected. The directive (`[ngui-auto-complete]`) stays
 loosely typed — Angular can't infer a generic for an attribute directive in templates, so its
 `(valueSelected)` payload is `NguiAutoCompleteSelection<any>`.
+
+---
+
+## Theming
+
+Restyle the dropdown by overriding these CSS variables. Each has a sensible default, so set only what you
+need. Set them on `:root` — the directive's dropdown renders in an overlay at the document root, so
+variables on an ancestor of the input won't reach it.
+
+| Variable | Default | Controls |
+|----------|---------|----------|
+| `--ngui-ac-background` | `#fff` | Dropdown background |
+| `--ngui-ac-color` | `inherit` | Text color |
+| `--ngui-ac-border` | `1px solid rgba(0,0,0,.12)` | Dropdown border |
+| `--ngui-ac-border-radius` | `4px` | Corner radius |
+| `--ngui-ac-shadow` | `0 4px 12px rgba(0,0,0,.15)` | Elevation shadow |
+| `--ngui-ac-max-height` | `256px` | Height cap (`none` to remove) |
+| `--ngui-ac-item-border` | `1px solid rgba(0,0,0,.06)` | Row divider |
+| `--ngui-ac-hover-background` | `rgba(0,0,0,.06)` | Row hover background |
+| `--ngui-ac-selected-background` | `rgba(0,0,0,.1)` | Highlighted row background |
+
+```scss
+/* e.g. a dark dropdown */
+:root {
+  --ngui-ac-background: #2b2b2b;
+  --ngui-ac-color: #eee;
+  --ngui-ac-item-border: 1px solid rgba(255, 255, 255, 0.08);
+  --ngui-ac-hover-background: rgba(255, 255, 255, 0.08);
+  --ngui-ac-selected-background: rgba(255, 255, 255, 0.16);
+}
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ The directive positions its dropdown with the [CDK Overlay](https://material.ang
 @import '@angular/cdk/overlay-prebuilt.css';
 ```
 
+> **Styling the dropdown:** because the directive renders its dropdown in an overlay at the document root,
+> any custom dropdown styles (e.g. classes used by a `list-formatter` or template) must be **global**, not
+> scoped to an ancestor of the input. The dropdown's height is capped by `--ngui-ac-max-height` (default
+> `256px`) — set it on `:root` to change it, or `--ngui-ac-max-height: none` to remove the cap.
+
 ## Setup
 
 ### Standalone (Angular 21+)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,15 @@ A versatile Angular autocomplete library that works as both a **directive** (att
 ## Installation
 
 ```bash
-npm install @ngui/auto-complete
+npm install @ngui/auto-complete @angular/cdk
+```
+
+The directive positions its dropdown with the [CDK Overlay](https://material.angular.io/cdk/overlay), so
+`@angular/cdk` is a peer dependency and your app must include the CDK overlay styles **once**:
+
+```scss
+/* styles.scss — skip this if you already import an Angular Material theme (it bundles them) */
+@import '@angular/cdk/overlay-prebuilt.css';
 ```
 
 ## Setup
@@ -204,11 +212,12 @@ Interaction and selection behavior.
 
 | Option | Type | Default | Applies to | Description |
 |--------|------|---------|------------|-------------|
-| `open-direction` | `'auto' \| 'up' \| 'down'` | `'auto'` | Both | Force the dropdown above (`up`) or below (`down`). For the directive, `auto` opens below unless the input is near the bottom of the viewport; for the component, `up` renders above via CSS and `auto`/`down` keep it below |
-| `z-index` | `number` | `1` | Directive | CSS `z-index` of the dropdown |
+| `open-direction` | `'auto' \| 'up' \| 'down'` | `'auto'` | Both | Preferred side. For the directive (CDK overlay) `up`/`down` set the preference and the overlay still flips when there isn't room; for the component, `up` renders above via CSS and `auto`/`down` keep it below |
+| `z-index` | `number` | `1` | Directive | z-index of the dropdown overlay. Rarely needed — the CDK overlay already renders above page content; only useful to order overlapping overlays |
 
-> **RTL:** there is no RTL input — the dropdown anchors via logical CSS (`inset-inline-start`), so an
-> ancestor `dir="rtl"` (or the document direction) positions it correctly on its own.
+> **RTL:** there is no RTL input — the directive's overlay follows the input's computed direction, and the
+> component's drop-up anchors via logical CSS (`inset-inline-start`). Just set `dir="rtl"` on the element or
+> an ancestor (or the document direction).
 
 ### Events
 

--- a/projects/auto-complete/package.json
+++ b/projects/auto-complete/package.json
@@ -22,6 +22,7 @@
     "tslib": "^2.8.1"
   },
   "peerDependencies": {
+    "@angular/cdk": "^21.0.0",
     "@angular/common": "^21.0.0",
     "@angular/core": "^21.0.0"
   }

--- a/projects/auto-complete/src/lib/auto-complete.component.scss
+++ b/projects/auto-complete/src/lib/auto-complete.component.scss
@@ -20,20 +20,22 @@
 	background-clip: content-box;
 }
 
+// Theming hooks: override any `--ngui-ac-*` variable to restyle the dropdown (e.g. for brand colors
+// or dark mode). The directive renders the dropdown in an overlay at the document root, so set these
+// on `:root` (not on an ancestor of the input) for them to take effect.
 .ngui-auto-complete > ul {
-	background-color: #fff;
+	background-color: var(--ngui-ac-background, #fff);
+	color: var(--ngui-ac-color, inherit);
 	margin: 0;
 	width: 100%;
-	// Overridable cap so long lists don't cover the page; set `--ngui-ac-max-height` (e.g. on
-	// :root, since the directive renders the dropdown in an overlay at the document root) to change
-	// it, or `--ngui-ac-max-height: none` to remove it.
+	// `--ngui-ac-max-height: none` removes the cap.
 	max-height: var(--ngui-ac-max-height, 256px);
 	overflow-y: auto;
 	list-style-type: none;
 	padding: 0;
-	border: 1px solid rgba(0, 0, 0, 0.12);
-	border-radius: 4px;
-	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+	border: var(--ngui-ac-border, 1px solid rgba(0, 0, 0, 0.12));
+	border-radius: var(--ngui-ac-border-radius, 4px);
+	box-shadow: var(--ngui-ac-shadow, 0 4px 12px rgba(0, 0, 0, 0.15));
 	box-sizing: border-box;
 	animation: slideDown 0.1s;
 }
@@ -52,12 +54,12 @@
 
 .ngui-auto-complete > ul li {
 	padding: 6px 12px;
-	border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+	border-bottom: var(--ngui-ac-item-border, 1px solid rgba(0, 0, 0, 0.06));
 	cursor: pointer;
 }
 
 .ngui-auto-complete > ul li.selected {
-	background-color: rgba(0, 0, 0, 0.1);
+	background-color: var(--ngui-ac-selected-background, rgba(0, 0, 0, 0.1));
 }
 
 .ngui-auto-complete > ul li:last-child {
@@ -65,5 +67,5 @@
 }
 
 .ngui-auto-complete > ul li:not(.header-item):hover {
-	background-color: rgba(0, 0, 0, 0.06);
+	background-color: var(--ngui-ac-hover-background, rgba(0, 0, 0, 0.06));
 }

--- a/projects/auto-complete/src/lib/auto-complete.component.scss
+++ b/projects/auto-complete/src/lib/auto-complete.component.scss
@@ -24,10 +24,13 @@
 	background-color: #fff;
 	margin: 0;
 	width: 100%;
+	max-height: 256px;
 	overflow-y: auto;
 	list-style-type: none;
 	padding: 0;
-	border: 1px solid #ccc;
+	border: 1px solid rgba(0, 0, 0, 0.12);
+	border-radius: 4px;
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 	box-sizing: border-box;
 	animation: slideDown 0.1s;
 }
@@ -45,12 +48,13 @@
 }
 
 .ngui-auto-complete > ul li {
-	padding: 2px 5px;
-	border-bottom: 1px solid #eee;
+	padding: 6px 12px;
+	border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+	cursor: pointer;
 }
 
 .ngui-auto-complete > ul li.selected {
-	background-color: #ccc;
+	background-color: rgba(0, 0, 0, 0.1);
 }
 
 .ngui-auto-complete > ul li:last-child {
@@ -58,5 +62,5 @@
 }
 
 .ngui-auto-complete > ul li:not(.header-item):hover {
-	background-color: #ccc;
+	background-color: rgba(0, 0, 0, 0.06);
 }

--- a/projects/auto-complete/src/lib/auto-complete.component.scss
+++ b/projects/auto-complete/src/lib/auto-complete.component.scss
@@ -24,7 +24,10 @@
 	background-color: #fff;
 	margin: 0;
 	width: 100%;
-	max-height: 256px;
+	// Overridable cap so long lists don't cover the page; set `--ngui-ac-max-height` (e.g. on
+	// :root, since the directive renders the dropdown in an overlay at the document root) to change
+	// it, or `--ngui-ac-max-height: none` to remove it.
+	max-height: var(--ngui-ac-max-height, 256px);
 	overflow-y: auto;
 	list-style-type: none;
 	padding: 0;

--- a/projects/auto-complete/src/lib/auto-complete.component.scss
+++ b/projects/auto-complete/src/lib/auto-complete.component.scss
@@ -53,7 +53,7 @@
 }
 
 .ngui-auto-complete > ul li {
-	padding: 6px 12px;
+	padding: var(--ngui-ac-item-padding, 6px 12px);
 	border-bottom: var(--ngui-ac-item-border, 1px solid rgba(0, 0, 0, 0.06));
 	cursor: pointer;
 }

--- a/projects/auto-complete/src/lib/auto-complete.directive.spec.ts
+++ b/projects/auto-complete/src/lib/auto-complete.directive.spec.ts
@@ -43,4 +43,23 @@ describe('NguiAutoCompleteDirective (ControlValueAccessor)', () => {
 		expect(fixture.componentInstance.value).toBe('Beta');
 		fixture.destroy();
 	}));
+
+	it('opens the dropdown in a CDK overlay on focus and removes it on hide', fakeAsync(() => {
+		const fixture = TestBed.createComponent(HostComponent);
+		fixture.detectChanges();
+		tick();
+
+		const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+		input.dispatchEvent(new Event('focus'));
+		tick();
+
+		expect(document.querySelector('.cdk-overlay-pane ngui-auto-complete')).toBeTruthy();
+
+		const directive = fixture.debugElement.query(By.directive(NguiAutoCompleteDirective)).injector.get(NguiAutoCompleteDirective);
+		directive.hideAutoCompleteDropdown();
+		tick(100); // dropdownJustHidden reset timer
+
+		expect(document.querySelector('.cdk-overlay-pane ngui-auto-complete')).toBeFalsy();
+		fixture.destroy();
+	}));
 });

--- a/projects/auto-complete/src/lib/auto-complete.directive.ts
+++ b/projects/auto-complete/src/lib/auto-complete.directive.ts
@@ -207,8 +207,11 @@ export class NguiAutoCompleteDirective implements OnInit, AfterViewInit, OnDestr
 		this.componentRef = this.overlayRef.attach(new ComponentPortal(NguiAutoCompleteComponent));
 
 		const component = this.componentRef.instance;
-		// The host is inline by default; make it fill the overlay's (input-matched) width.
-		(this.componentRef.location.nativeElement as HTMLElement).style.display = 'block';
+		// The host is an inline custom element and the overlay pane is a flex container, so it would
+		// otherwise shrink to its content. Force it to fill the overlay's (input-matched) width.
+		const host = this.componentRef.location.nativeElement as HTMLElement;
+		host.style.display = 'block';
+		host.style.width = '100%';
 		component.keyword = this.inputEl.value;
 
 		// Forward inputs to the dynamically created dropdown component. Signal inputs are

--- a/projects/auto-complete/src/lib/auto-complete.directive.ts
+++ b/projects/auto-complete/src/lib/auto-complete.directive.ts
@@ -13,6 +13,8 @@ import {
 	input,
 	output,
 } from '@angular/core';
+import { ConnectedPosition, Overlay, OverlayRef } from '@angular/cdk/overlay';
+import { ComponentPortal } from '@angular/cdk/portal';
 import { Subscription } from 'rxjs';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { NguiAutoCompleteComponent, NguiAutoCompleteSelection } from './auto-complete.component';
@@ -30,6 +32,7 @@ import { NguiAutoCompleteComponent, NguiAutoCompleteSelection } from './auto-com
 })
 export class NguiAutoCompleteDirective implements OnInit, AfterViewInit, OnDestroy, ControlValueAccessor {
 	viewContainerRef = inject(ViewContainerRef);
+	private overlay = inject(Overlay);
 
 	public autocomplete = input(false, { transform: booleanAttribute });
 	public autoCompletePlaceholder = input('', { alias: 'auto-complete-placeholder' });
@@ -76,9 +79,8 @@ export class NguiAutoCompleteDirective implements OnInit, AfterViewInit, OnDestr
 	public noMatchFound = output<void>();
 
 	private componentRef: ComponentRef<NguiAutoCompleteComponent>;
-	private wrapperEl: HTMLElement;
+	private overlayRef: OverlayRef | null = null;
 	private el: HTMLElement;
-	private acDropdownEl: HTMLElement;
 	private inputEl: HTMLInputElement;
 	private value: any;
 	private revertValue: any;
@@ -108,12 +110,6 @@ export class NguiAutoCompleteDirective implements OnInit, AfterViewInit, OnDestr
 		};
 
 		document.addEventListener('click', this.documentClickListener);
-		// wrap this element with <div class="ngui-auto-complete">
-		this.wrapperEl = document.createElement('div');
-		this.wrapperEl.className = 'ngui-auto-complete-wrapper';
-		this.wrapperEl.style.position = 'relative';
-		this.el.parentElement.insertBefore(this.wrapperEl, this.el.nextSibling);
-		this.wrapperEl.appendChild(this.el);
 	}
 
 	ngAfterViewInit() {
@@ -146,9 +142,11 @@ export class NguiAutoCompleteDirective implements OnInit, AfterViewInit, OnDestr
 
 	ngOnDestroy(): void {
 		this.dropdownSubs.unsubscribe();
-		if (this.componentRef) {
-			this.componentRef.destroy();
+		if (this.overlayRef) {
+			this.overlayRef.dispose();
+			this.overlayRef = null;
 		}
+		this.componentRef = undefined;
 		if (this.documentClickListener) {
 			document.removeEventListener('click', this.documentClickListener);
 		}
@@ -180,7 +178,7 @@ export class NguiAutoCompleteDirective implements OnInit, AfterViewInit, OnDestr
 		this.renderValue(item === null || item === undefined ? '' : item);
 	}
 
-	// show auto-complete list below the current element
+	// show auto-complete list anchored to the current element via a CDK overlay
 	public showAutoCompleteDropdown = (event?: any): void => {
 		if (this.dropdownJustHidden) {
 			return;
@@ -188,9 +186,29 @@ export class NguiAutoCompleteDirective implements OnInit, AfterViewInit, OnDestr
 		this.hideAutoCompleteDropdown();
 		this.scheduledBlurHandler = null;
 
-		this.componentRef = this.viewContainerRef.createComponent(NguiAutoCompleteComponent);
+		// Render the dropdown in a CDK overlay anchored to the input. The overlay lives at the
+		// document root, so it escapes any ancestor's clipping / stacking context (e.g. a
+		// mat-form-field), and the position strategy flips it above/below on overflow.
+		this.overlayRef = this.overlay.create({
+			width: this.inputEl.getBoundingClientRect().width,
+			scrollStrategy: this.overlay.scrollStrategies.reposition(),
+			direction: (getComputedStyle(this.inputEl).direction as 'ltr' | 'rtl') || 'ltr',
+			positionStrategy: this.overlay
+				.position()
+				.flexibleConnectedTo(this.inputEl)
+				.withFlexibleDimensions(false)
+				.withPush(false)
+				.withPositions(this.dropdownPositions()),
+		});
+		// Honour the z-index input within the overlay layer (rarely needed — the overlay already
+		// renders above page content; useful only to order overlapping overlays).
+		this.overlayRef.hostElement.style.zIndex = '' + this.zIndex();
+
+		this.componentRef = this.overlayRef.attach(new ComponentPortal(NguiAutoCompleteComponent));
 
 		const component = this.componentRef.instance;
+		// The host is inline by default; make it fill the overlay's (input-matched) width.
+		(this.componentRef.location.nativeElement as HTMLElement).style.display = 'block';
 		component.keyword = this.inputEl.value;
 
 		// Forward inputs to the dynamically created dropdown component. Signal inputs are
@@ -221,27 +239,22 @@ export class NguiAutoCompleteDirective implements OnInit, AfterViewInit, OnDestr
 		this.dropdownSubs.add(component.valueSelected.subscribe(this.onSelection));
 		this.dropdownSubs.add(component.noMatchFound.subscribe(() => this.noMatchFound.emit()));
 
-		this.acDropdownEl = this.componentRef.location.nativeElement;
-		this.acDropdownEl.style.display = 'none';
-
-		// if this element is not an input tag, move dropdown after input tag
-		// so that it displays correctly
-
-		// TODO: confirm with owners
-		// with some reason, viewContainerRef.createComponent is creating element
-		// to parent div which is created by us on ngOnInit, please try this with demo
-
-		// if (this.el.tagName !== 'INPUT' && this.acDropdownEl) {
-		this.inputEl.parentElement.insertBefore(this.acDropdownEl, this.inputEl.nextSibling);
-		// }
 		this.revertValue = typeof this.revertValue !== 'undefined' ? this.revertValue : '';
 
 		setTimeout(() => {
 			component.reloadList(this.inputEl.value);
-			this.styleAutoCompleteDropdown();
 			component.dropdownVisible.set(true);
+			this.overlayRef?.updatePosition();
 		});
 	};
+
+	// Preferred connected positions, ordered by `open-direction`. CDK falls through the list and
+	// flips on overflow; `auto`/`down` prefer below, `up` prefers above.
+	private dropdownPositions(): ConnectedPosition[] {
+		const below: ConnectedPosition = { originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top' };
+		const above: ConnectedPosition = { originX: 'start', originY: 'top', overlayX: 'start', overlayY: 'bottom' };
+		return this.openDirection() === 'up' ? [above, below] : [below, above];
+	}
 
 	public blurHandler(event: any) {
 		if (this.componentRef) {
@@ -266,7 +279,10 @@ export class NguiAutoCompleteDirective implements OnInit, AfterViewInit, OnDestr
 				currentItem = this.componentRef.instance.findItemFromSelectValue(this.inputEl.value);
 			}
 			this.dropdownSubs.unsubscribe();
-			this.componentRef.destroy();
+			if (this.overlayRef) {
+				this.overlayRef.dispose();
+				this.overlayRef = null;
+			}
 			this.componentRef = undefined;
 
 			if (this.inputEl && hasRevertValue && this.acceptUserInput() === false && currentItem === null && this.inputEl.value !== '') {
@@ -280,44 +296,6 @@ export class NguiAutoCompleteDirective implements OnInit, AfterViewInit, OnDestr
 		this.dropdownJustHidden = true;
 		setTimeout(() => (this.dropdownJustHidden = false), 100);
 	};
-
-	public styleAutoCompleteDropdown = () => {
-		if (this.componentRef) {
-			/* setting width/height auto complete */
-			const thisInputElBCR = this.inputEl.getBoundingClientRect();
-
-			this.acDropdownEl.style.width = thisInputElBCR.width + 'px';
-			this.acDropdownEl.style.position = 'absolute';
-			this.acDropdownEl.style.zIndex = '' + this.zIndex();
-			// Anchor on the leading edge; `inset-inline-start` follows the element's direction
-			// (LTR → left, RTL → right) automatically, so RTL needs no detection.
-			this.acDropdownEl.style.insetInlineStart = '0';
-			this.acDropdownEl.style.display = 'inline-block';
-
-			// Reset any previous vertical anchor so re-styling is deterministic.
-			this.acDropdownEl.style.top = '';
-			this.acDropdownEl.style.bottom = '';
-
-			if (this.shouldOpenUp(thisInputElBCR)) {
-				this.acDropdownEl.style.bottom = `${thisInputElBCR.height}px`;
-			} else {
-				this.acDropdownEl.style.top = `${thisInputElBCR.height}px`;
-			}
-		}
-	};
-
-	// Resolve the vertical opening direction honouring the `open-direction` input.
-	// 'auto' keeps the historic heuristic: open above only when the input is within
-	// ~100px of the viewport bottom.
-	private shouldOpenUp(inputBCR: DOMRect): boolean {
-		if (this.openDirection() === 'up') {
-			return true;
-		}
-		if (this.openDirection() === 'down') {
-			return false;
-		}
-		return inputBCR.bottom + 100 > window.innerHeight;
-	}
 
 	public setToStringFunction(item: any): any {
 		if (item && typeof item === 'object') {

--- a/projects/demo/src/styles.scss
+++ b/projects/demo/src/styles.scss
@@ -168,50 +168,49 @@ body {
 			word-break: break-word;
 		}
 	}
+}
 
-	// Grid demo specific styles
-	.header-row {
-		background: #455a64;
-		color: white;
-		padding: 4px 0;
-		border-radius: 2px;
-		font-size: 12px;
-		font-weight: 500;
-	}
+// Dropdown content produced by `list-formatter` strings and header templates. The directive renders
+// the dropdown in a CDK overlay at the document root, so this content lives outside any component's
+// style scope and must be styled globally (not nested under `.demo-card`).
+.header-row {
+	background: #455a64;
+	color: white;
+	padding: 4px 0;
+	border-radius: 2px;
+	font-size: 12px;
+	font-weight: 500;
+}
 
-	.data-row {
-		font-size: 12px;
-		border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+.data-row {
+	font-size: 12px;
+	border-bottom: 1px solid rgba(0, 0, 0, 0.08);
 
-		&:last-child {
-			border-bottom: none;
-		}
-	}
-
-	.col-1 {
-		display: inline-block;
-		width: 90px;
-		padding: 2px 6px;
-		border-left: 1px solid rgba(0, 0, 0, 0.12);
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-	}
-
-	.col-2 {
-		display: inline-block;
-		width: 160px;
-		padding: 2px 6px;
-		border-left: 1px solid rgba(0, 0, 0, 0.12);
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
+	&:last-child {
+		border-bottom: none;
 	}
 }
 
-// Dropdown row content produced by `list-formatter` strings. These are rendered into the
-// library dropdown via [innerHtml], so they live outside any component's style scope and
-// must be styled globally.
+.col-1 {
+	display: inline-block;
+	width: 90px;
+	padding: 2px 6px;
+	border-inline-start: 1px solid rgba(0, 0, 0, 0.12);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.col-2 {
+	display: inline-block;
+	width: 160px;
+	padding: 2px 6px;
+	border-inline-start: 1px solid rgba(0, 0, 0, 0.12);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
 .amount-cell {
 	text-align: end;
 }


### PR DESCRIPTION
## Area

Library — the directive's dropdown positioning core. Part of the v21.0.0 series. **This is the big one — needs a visual once-over (see below).**

## What & why

The directive used to render its dropdown as an absolutely-positioned element inserted next to the input (with a wrapper `<div>`, manual width/`z-index`, and hand-rolled open-up math). That can't escape an ancestor's clipping or stacking context — hence the dropdown getting painted **behind** sibling content (e.g. inside a `mat-form-field`, or a card with `overflow: hidden`).

This renders the dropdown through the **CDK Overlay**: a `ComponentPortal` attached to an overlay at the document root, anchored to the input via `flexibleConnectedTo`.

Result:
- **Escapes clipping/stacking** — fixes the "dropdown behind the panel" bug from PR #496's Material card.
- **Auto-flips** above/below on overflow → `open-direction` is now a *preference* (still flips when there's no room).
- **RTL** follows the input's computed direction.
- **Repositions on scroll.**
- `z-index` is kept but now only orders overlapping overlays (the overlay already layers above page content).
- Outside-click / blur / keyboard handling unchanged.

Removed: the wrapper `<div>`, `styleAutoCompleteDropdown`, `shouldOpenUp`, the inline insert. The standalone **component** is unchanged (its CSS drop-up still applies; overlay is directive-only — Angular can't host a generic attribute directive's content in an overlay otherwise).

## ⚠️ Breaking + setup

- **`@angular/cdk@^21` is now a peer dependency.**
- Apps must include the CDK overlay styles **once**: `@import '@angular/cdk/overlay-prebuilt.css';` — or any Angular Material theme (bundles them). Documented in README + MIGRATION.

## Please eyeball when reviewing (I can't verify positioning headlessly)

- Dropdown opens in the right place below/above the input, flips near the viewport bottom.
- The **Material Integration** card (PR #496) — dropdown should now sit **above** the "View Template" panel.
- RTL card anchors correctly.
- Item click selects; outside click / blur closes; Tab/Enter/arrows still work; re-focus after select.

## Validation

`build-lib:prod` · `build-docs` · `lint` · `ng test auto-complete` (15/15, +1 overlay attach/detach test) · `ng test demo` (5/5) · `format:check` — all green.

## Notes

- Not merging from my side — please review and merge.
- Overlaps `auto-complete.directive.ts` + CHANGELOG/README/MIGRATION with #498 (`source.required`); I'll rebase whichever merges second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
