### PR TITLE
chore: add funding links (GitHub Sponsors + PayPal)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: almothafar
+custom: ['https://paypal.me/almothafar']

--- a/projects/auto-complete/package.json
+++ b/projects/auto-complete/package.json
@@ -12,6 +12,16 @@
     "url": "https://github.com/ng2-ui/auto-complete/issues"
   },
   "homepage": "https://github.com/ng2-ui/auto-complete#readme",
+  "funding": [
+    {
+      "type": "github",
+      "url": "https://github.com/sponsors/almothafar"
+    },
+    {
+      "type": "individual",
+      "url": "https://paypal.me/almothafar"
+    }
+  ],
   "keywords": [
     "angular",
     "auto-complete",


### PR DESCRIPTION
## What

Adds funding/sponsorship links in two places:

- **`.github/FUNDING.yml`** — enables the **Sponsor** button on the repo header (GitHub Sponsors + PayPal).
- **`funding` field in `projects/auto-complete/package.json`** — surfaces a funding link on the npm package page and via `npm fund` for consumers of `@ngui/auto-complete`. Ships with the next release.

```yaml
github: almothafar
custom: ['https://paypal.me/almothafar']
```

## Notes

- Repo-only metadata; no code, no API, no version bump.
- `package.json` kept at the repo's 2-space JSON style (the `format:check` gate only globs `*.{ts,html,scss}`, so JSON isn't prettier-managed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)