### PR TITLE
build: enable strict template type-checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project follows [Angular version numbers](https://angular.dev/reference
 
 ---
 
+## [21.0.1] — unreleased
+
+### Internal (development tooling only — no impact on consumers)
+- **Enabled strict template type-checking** (`strictTemplates: true` in the root `angularCompilerOptions`),
+  the natural companion to the `strict: true` adopted in 21.0.0. The library compiles cleanly under it; the
+  only fix needed was a more precise type on a demo field (`open-direction` binding). No public API or
+  runtime behavior change — this only tightens the library's own build.
+
+---
+
 ## [21.0.0] — 2026-06-04
 
 ### ⚠️ BREAKING CHANGES

--- a/projects/auto-complete/package.json
+++ b/projects/auto-complete/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngui/auto-complete",
-  "version": "21.0.0",
+  "version": "21.0.1",
   "description": "Angular Input Autocomplete",
   "license": "MIT",
   "repository": {

--- a/projects/demo/src/app/directive-test/directive-test.component.ts
+++ b/projects/demo/src/app/directive-test/directive-test.component.ts
@@ -106,7 +106,7 @@ export class DirectiveTestComponent {
 	public directionWord = ''; // open-direction
 
 	public noMatchVisible = false;
-	public openDir = 'auto';
+	public openDir: 'auto' | 'up' | 'down' = 'auto';
 
 	// Bound to the live "accept-user-input" toggles in two of the cards.
 	public tagAcceptInput = true;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,7 @@
   },
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,
-    "strictInjectionParameters": true
+    "strictInjectionParameters": true,
+    "strictTemplates": true
   }
 }


### PR DESCRIPTION
## What

Enables Angular's **strict template type-checking** (`strictTemplates: true` in the root `angularCompilerOptions`) — the natural companion to the `strict: true` TypeScript mode adopted in 21.0.0 (#500).

The library compiles **cleanly** under it. The only fix needed was a more precise type on a **demo** field bound to `[open-direction]`:

```diff
- public openDir = 'auto';
+ public openDir: 'auto' | 'up' | 'down' = 'auto';
```

This is an internal build-hardening change only — **no public API or runtime behavior change** for consumers. Going forward, template type errors (wrong binding types, bad `$event`/template-ref usage, etc.) are caught at build time.

## Validation gate

| Step | Result |
| --- | --- |
| `build-lib:prod` | ✅ |
| `build-docs` | ✅ (no NG8113) |
| `ng test auto-complete` | ✅ 16/16 |
| `ng test demo` | ✅ 5/5 |
| `lint` | ✅ |
| `format:check` | ✅ |

## Notes
- Versioned `21.0.1` (patch — internal tooling only), CHANGELOG entry under "Internal".
- Independent of the Angular 22 work (#502): this builds clean on Angular 21, so it can land first. Once merged, I'll rebase #502 on top (its `strictTemplates: false` becomes `true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)