### PR TITLE
docs: complete the 21.0.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,18 @@ and this project follows [Angular version numbers](https://angular.dev/reference
 
 ## [21.0.1] — unreleased
 
+### Added
+- **Funding metadata.** The published `package.json` now carries a `funding` field (GitHub Sponsors +
+  PayPal), surfaced on the npm page and via `npm fund` (#501).
+
 ### Internal (development tooling only — no impact on consumers)
+- **Enabled TypeScript `strict` mode** (`strict: true`) and tightened types accordingly — replacing
+  remaining `any`s with precise types (e.g. `ReturnType<typeof setTimeout>`, generics, `unknown`) and
+  adding null-safety guards. No public API or runtime behavior change (#500).
 - **Enabled strict template type-checking** (`strictTemplates: true` in the root `angularCompilerOptions`),
-  the natural companion to the `strict: true` adopted in 21.0.0. The library compiles cleanly under it; the
-  only fix needed was a more precise type on a demo field (`open-direction` binding). No public API or
-  runtime behavior change — this only tightens the library's own build.
+  the natural companion to `strict` above. The library compiles cleanly under it; the only fix needed was a
+  more precise type on a demo field (`open-direction` binding). No public API or runtime behavior change —
+  this only tightens the library's own build (#503).
 
 ---
 


### PR DESCRIPTION
## What

The `[21.0.1]` changelog only documented `strictTemplates` (#503), but there are **three** unreleased changes since `21.0.0` — and one was mis-attributed. This completes the entry:

- **Added** #500 — TypeScript `strict` mode + type tightening (was missing entirely).
- **Added** #501 — the published-package `funding` field (was missing).
- **Fixed** the wording that said `strict: true` was "adopted in 21.0.0" — it actually landed *after* the 21.0.0 release, so it belongs in 21.0.1.

Docs-only; no code change. (`master`'s library version is already `21.0.1` from #503, so this just makes the section accurate whenever it's released — standalone or folded into v22.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)