### PR TITLE
fix: float the standalone component dropdown so it overlays content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,21 @@ and this project follows [Angular version numbers](https://angular.dev/reference
 
 ## [22.0.0] — unreleased
 
-A framework-only major: the public API is unchanged from 21.x. The only consumer-visible change is the
-bumped Angular peer requirement.
+A framework-only major: the public API is unchanged from 21.x. The consumer-visible changes are the
+bumped Angular peer requirement and one dropdown-positioning fix (below).
 
 ### ⚠️ BREAKING CHANGES
 - **Requires Angular 22.** `peerDependencies` now require `@angular/cdk`, `@angular/common` and
   `@angular/core` `^22.0.0`. Angular 21 and older projects must stay on `@ngui/auto-complete@21` (or the
   matching major).
+
+### Fixed
+- **Standalone `<ngui-auto-complete>` dropdown now overlays the content below it instead of pushing it
+  down.** When opening downward (the default), the list was rendered in normal document flow, so it grew
+  its host and could scroll the page; it now floats (`position: absolute; top: 100%`), matching the
+  existing upward (`dropup`) behavior. The directive's CDK-overlay path is unchanged. The float layer uses
+  `z-index: var(--ngui-ac-z-index, 10)`, so you can override `--ngui-ac-z-index` if it collides with other
+  stacked UI.
 
 ### Internal (development tooling only — no impact on consumers)
 - `ng update` to Angular 22: `@angular/cli` + `@angular/build` 22.0.0, `@angular/cdk` + `@angular/material`

--- a/projects/auto-complete/src/lib/auto-complete.component.scss
+++ b/projects/auto-complete/src/lib/auto-complete.component.scss
@@ -24,6 +24,12 @@
 // or dark mode). The directive renders the dropdown in an overlay at the document root, so set these
 // on `:root` (not on an ancestor of the input) for them to take effect.
 .ngui-auto-complete > ul {
+	// Float the list below the input so it overlays following content instead of pushing it down
+	// (which would expand the host and scroll the page). The `.dropup` variant flips this above.
+	position: absolute;
+	top: 100%;
+	inset-inline-start: 0;
+	z-index: var(--ngui-ac-z-index, 10);
 	background-color: var(--ngui-ac-background, #fff);
 	color: var(--ngui-ac-color, inherit);
 	margin: 0;
@@ -45,11 +51,17 @@
 }
 
 .ngui-auto-complete > ul.dropup {
-	position: absolute;
+	// Flip above the input. `inset-inline-start: 0` is inherited from the base rule and
+	// anchors LTR→left / RTL→right automatically, so RTL needs no override.
+	top: auto;
 	bottom: 100%;
-	// Logical inline-start anchors LTR→left / RTL→right automatically (matches the
-	// directive's inset-inline-start positioning), so RTL needs no override.
-	inset-inline-start: 0;
+}
+
+// The directive renders this component inside a CDK overlay, which already floats the list at the
+// document root and must measure its height to flip/reposition on overflow. Keep the list in
+// normal flow there so the overlay pane sizes to it (the standalone component is never in a pane).
+.cdk-overlay-pane .ngui-auto-complete > ul {
+	position: static;
 }
 
 .ngui-auto-complete > ul li {


### PR DESCRIPTION
## Problem

When `<ngui-auto-complete>` is used as a **standalone component** and its dropdown opens **downward** (the default), the list `<ul>` is rendered in **normal document flow**. So it takes up layout space — expanding its host, growing the surrounding card, and scrolling the page — instead of floating over the content below.

Only the upward `.dropup` variant was floated (`position: absolute; bottom: 100%`); the down case had no positioning. That asymmetry is the bug.

## Fix

In [`auto-complete.component.scss`](projects/auto-complete/src/lib/auto-complete.component.scss), float the list by default, mirroring `.dropup`:

```scss
.ngui-auto-complete > ul {
  position: absolute;
  top: 100%;
  inset-inline-start: 0;
  z-index: var(--ngui-ac-z-index, 10);
  /* … */
}
.ngui-auto-complete > ul.dropup { top: auto; bottom: 100%; }
```

The **directive** renders this same component inside a **CDK overlay**, which already floats the list and must measure its height to flip/reposition on overflow. So a single scoped rule keeps the list in normal flow *only* there, leaving the directive/overlay behavior byte-for-byte unchanged:

```scss
.cdk-overlay-pane .ngui-auto-complete > ul { position: static; }
```

(The component uses `ViewEncapsulation.None`, so these are plain global rules — no `:host`, and no directive change needed.)

A new `--ngui-ac-z-index` CSS variable (default `10`) lets consumers adjust the float layer if it collides with other stacked UI.

## Validation

- `npm run build-lib:prod` ✅
- `npm run build-docs` ✅
- `npx ng test auto-complete` → **16/16** ✅ (incl. the directive overlay open/hide test)
- `npm run format:check` ✅
- Verified visually in the demo: the three Component-tab examples now overlay instead of pushing; the Directive-tab examples (normal, open-direction "up", and near-viewport-bottom flip) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)