### PR TITLE
docs: clarify publish step, v22 migration, and license holders

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2016 Allen Kim <allenhwkim@gmail.com>
+Copyright (c) 2016-2026 Allen Kim <allenhwkim@gmail.com>, Al-Mothafar Al-Hasan <almothafar@gmail.com>
 
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -19,7 +19,11 @@ ng update @angular/core@22 @angular/cli@22 @angular/cdk@22
 npm install @ngui/auto-complete@22
 ```
 
-Everything else — inputs, outputs, templates, theming, the CDK overlay setup from v21 — is unchanged.
+Inputs, outputs, templates and the CDK overlay setup from v21 are unchanged. The only consumer-visible
+behaviour change is a fix: the **standalone `<ngui-auto-complete>` dropdown now floats over the content
+below it** instead of pushing it down (matching the directive and the existing drop-up). The float layer
+uses `z-index: var(--ngui-ac-z-index, 10)` — override the new `--ngui-ac-z-index` theming variable if it
+collides with other stacked UI.
 
 ### Zoneless apps are fully supported
 

--- a/README.md
+++ b/README.md
@@ -337,7 +337,8 @@ npm start
 
 ```bash
 # 1. Update version in projects/auto-complete/package.json
-# 2. Build the library and copy README/CHANGELOG/LICENSE into dist/
+# 2. Build the library. This also copies README/CHANGELOG/MIGRATION/LICENSE
+#    into dist/ for you (via the copy-lib script).
 npm run build-lib:prod
 
 # 3. Move into the built output — do NOT run npm publish from the project root


### PR DESCRIPTION
@
## Summary

Documentation-only corrections found while reviewing the project Markdown — three small factual/clarity fixes, no code or behaviour change.

## Area

- [x] 📝 Docs

## Changes

- **README** — the "Publish a new version" step described copying README/CHANGELOG/LICENSE into `dist/` as a manual action and omitted MIGRATION. `build-lib:prod` already runs `copy-lib`, which copies README/CHANGELOG/**MIGRATION**/LICENSE automatically; the wording now reflects that.
- **MIGRATION (v21 → v22)** — the "everything is unchanged" line contradicted the 22.0.0 CHANGELOG. It now notes the one consumer-visible fix (standalone `<ngui-auto-complete>` dropdown now floats instead of pushing content) and the new `--ngui-ac-z-index` theming variable.
- **LICENSE** — added the current maintainer as a copyright holder and switched to a `2016-2026` range.

## Impact

None — documentation only. No public API, runtime, or build change.

## How to test

Read-through; Markdown is in `.prettierignore` so the format gate is unaffected, and there are no code changes to build/lint/test.

## Checklist

- [x] Scope is small and single-concern
- [x] Conventional Commit title
- [x] Docs-only — no code change, so the build/lint/test gate is N/A
- [x] No `build-info.ts` timestamp committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@