### PR TITLE
chore: drop @angular/animations from the demo (Material v22 is CSS-based)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@angular/animations": "^22.0.2",
         "@angular/cdk": "^22.0.2",
         "@angular/common": "^22.0.2",
         "@angular/compiler": "^22.0.2",
@@ -454,22 +453,6 @@
         "@typescript-eslint/utils": "^8.0.0",
         "eslint": "^9.0.0 || ^10.0.0",
         "typescript": "*"
-      }
-    },
-    "node_modules/@angular/animations": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-22.0.2.tgz",
-      "integrity": "sha512-l9lVG9k+baFMWXNsFUxwmxQaUZMkpkTn3vRpa1hs/vABzT/KnaDeweDtvvkS0NS1RYJenoxhONlMNEWuJ4VR1A==",
-      "deprecated": "@angular/animations is deprecated. Use `animate.enter` and `animate.leave` instead. For more information see: https://v22.angular.dev/guide/animations.",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "22.0.2"
       }
     },
     "node_modules/@angular/build": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "projects/**/*.{ts,html,scss}": "prettier --write"
   },
   "dependencies": {
-    "@angular/animations": "^22.0.2",
     "@angular/cdk": "^22.0.2",
     "@angular/common": "^22.0.2",
     "@angular/compiler": "^22.0.2",

--- a/projects/demo/src/main.ts
+++ b/projects/demo/src/main.ts
@@ -1,6 +1,5 @@
 import { enableProdMode, provideZonelessChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideHttpClient, withInterceptorsFromDi, withXhr } from '@angular/common/http';
 import { provideRouter, withHashLocation } from '@angular/router';
 
@@ -18,7 +17,6 @@ bootstrapApplication(AppComponent, {
 		provideZonelessChangeDetection(),
 		provideRouter(routes, withHashLocation()),
 		provideHttpClient(withXhr(), withInterceptorsFromDi()),
-		provideAnimations(),
 		AppService,
 	],
 }).catch((err) => console.error(err));


### PR DESCRIPTION
## What

Removes `@angular/animations` from the demo — both the `provideAnimations()` bootstrap call and the dependency.

## Why

- **Angular Material v22 (and CDK) no longer peer-depend on `@angular/animations`** — Material's animations are CSS-based now, so `provideAnimations()` is dead weight.
- `@angular/animations` is **deprecated** upstream (the install-time warning you saw), in favour of native `animate.enter` / `animate.leave`.
- The published library never referenced animations — this is demo-only.

## Changes

- `projects/demo/src/main.ts`: remove `provideAnimations()` and its `@angular/platform-browser/animations` import.
- `package.json`: remove `@angular/animations` from `dependencies`.

## Effect

- Resolves the `@angular/animations is deprecated` install warning.
- Production demo bundle drops **~64 kB raw** (the animations engine is no longer bundled).

## Validation gate — all green

- ✅ `npm run build-lib:prod`
- ✅ `npm run build-docs` (no NG8113; bundle smaller)
- ✅ `npm run lint`
- ✅ `npx ng test auto-complete --watch=false` → 16 passed
- ✅ `npx ng test demo --watch=false` → 5 passed
- ✅ `npm run format:check`

> ⚠️ **Manual check suggested:** unit tests run in jsdom and don't exercise visual transitions. Worth a quick local run-through of the demo to confirm Material interactions (dropdown open/close, tab switches, ripples) still look right without the animations provider. Material v22 being CSS-based, this should be a no-op visually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
