### PR TITLE
chore(tsconfig): use module "preserve" to match the Angular 22 default

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "esModuleInterop": true,
     "declaration": false,
     "experimentalDecorators": true,
-    "module": "ES2020",
+    "module": "preserve",
     "moduleResolution": "bundler",
     "importHelpers": true,
     "target": "ES2022",


### PR DESCRIPTION
## What

Changes the base `tsconfig.json` `module` setting from `"ES2020"` to `"preserve"`.

## Why

Angular CLI 22 scaffolds new workspaces with `"module": "preserve"` (paired with `"moduleResolution": "bundler"`, which this project already uses). `preserve` keeps `import`/`export` syntax intact and lets the bundler decide the final module format — the modern, recommended configuration. This just brings the base tsconfig in line with the current Angular 22 default.

## Changes

- `tsconfig.json`: `"module": "ES2020"` → `"preserve"`.

No behavioural change — purely a compiler configuration modernization.

## Validation gate — all green

- ✅ `npm run build-lib:prod`
- ✅ `npm run build-docs` (no NG8113)
- ✅ `npm run lint`
- ✅ `npx ng test auto-complete --watch=false` → 16 passed
- ✅ `npx ng test demo --watch=false` → 5 passed
- ✅ `npm run format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
