### PR TITLE
ci: add Dependabot config, bump CI actions, run unit tests in CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,76 @@
+version: 2
+
+updates:
+  # ── npm dependencies (Angular workspace) ──────────────────────────────
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'saturday'
+      time: '06:00'
+      timezone: 'Etc/UTC'
+    open-pull-requests-limit: 10
+    labels:
+      - 'dependencies'
+    commit-message:
+      prefix: 'chore(deps)'
+      prefix-development: 'chore(deps-dev)'
+    groups:
+      angular:
+        patterns:
+          - '@angular/*'
+          - '@angular-eslint/*'
+          - 'angular-eslint'
+          - 'ng-packagr'
+      linting:
+        patterns:
+          - 'eslint'
+          - '@eslint/*'
+          - 'typescript-eslint'
+          - '@typescript-eslint/*'
+          - 'eslint-plugin-*'
+      testing:
+        patterns:
+          - 'vitest'
+          - '@vitest/*'
+          - 'jsdom'
+          - 'cypress'
+          - '@cypress/*'
+      types:
+        patterns:
+          - '@types/*'
+    ignore:
+      # Angular majors must be done via `ng update` (it runs schematic migrations);
+      # Dependabot would only produce a broken partial bump. Remove these if you'd
+      # rather Dependabot surface (but not auto-fix) major Angular releases.
+      - dependency-name: '@angular/*'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@angular-eslint/*'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'angular-eslint'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'ng-packagr'
+        update-types: ['version-update:semver-major']
+      # TypeScript is locked to Angular's supported range (~6.0.x). Angular drives it;
+      # only allow patch bumps within 6.0.
+      - dependency-name: 'typescript'
+        update-types:
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'
+
+  # ── GitHub Actions (CI workflow) ──────────────────────────────────────
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'saturday'
+    open-pull-requests-limit: 5
+    labels:
+      - 'dependencies'
+      - 'github-actions'
+    commit-message:
+      prefix: 'ci(deps)'
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -32,6 +32,12 @@ jobs:
 
       - name: Build library
         run: npm run build-lib:prod
+
+      - name: Test (library)
+        run: npx ng test auto-complete --watch=false
+
+      - name: Test (demo)
+        run: npx ng test demo --watch=false
 
       - name: Build demo docs
         run: npm run build-docs
@@ -54,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Download docs artifact
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## What & why

Two adjacent CI/automation improvements:

### 1. Dependabot (`.github/dependabot.yml`)

New weekly grouped update config (adapted from the sibling `angular-signature-pad` setup), tuned to this repo's toolchain:

- **npm** — grouped PRs for `angular` (`@angular/*`, `@angular-eslint/*`, `angular-eslint`, `ng-packagr`), `linting` (eslint + typescript-eslint), `testing` (vitest, jsdom, cypress), and `types` (`@types/*`).
- **github-actions** — grouped into a single PR.
- **Ignored**: Angular / angular-eslint / ng-packagr **majors** (those need `ng update` schematic migrations, not a partial Dependabot bump) and TypeScript **major+minor** (pinned to Angular's supported `~6.0.x`).

### 2. CI actions + test gate (`.github/workflows/ci.yml`)

- Bump the only stale action: `actions/checkout@v6` → `@v7` (everything else was already current).
- Run the unit-test gate in CI (`ng test auto-complete` + `ng test demo`). The recent **Vitest + jsdom** migration made the tests browser-free, so they run in the Node runner with no Chrome install — previously CI built but never ran the tests.

## Validation

CI-config only — no library or app source touched, so **no release and no CHANGELOG entry**. Both YAML files validated as well-formed.

Generated with [Claude Code](https://claude.com/claude-code)
