### PR TITLE
docs(readme): modernize status badges

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,8 @@ Angular CLI monorepo with two projects:
 The demo **consumes the built library from `dist/`**, not the source — rebuild the library before the demo
 (or your editor) reflects library changes. The library's major version tracks the supported Angular major
 (`@ngui/auto-complete@N` ⇒ Angular `N`); don't introduce a major that doesn't line up with an Angular major.
+When bumping the Angular major, also update the static **Angular badge** in `README.md` (it's hard-coded,
+e.g. `Angular-22`).
 
 ## Commands (from the repo root)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # @ngui/auto-complete
 
-[![CI](https://github.com/ng2-ui/auto-complete/actions/workflows/ci.yml/badge.svg)](https://github.com/ng2-ui/auto-complete/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/npm/v/@ngui/auto-complete.svg)](https://www.npmjs.com/package/@ngui/auto-complete)
-[![npm downloads](https://img.shields.io/npm/dt/@ngui/auto-complete.svg)](https://www.npmjs.com/package/@ngui/auto-complete)
-[![npm license](https://img.shields.io/npm/l/@ngui/auto-complete.svg)](https://www.npmjs.com/package/@ngui/auto-complete)
-[![GitHub issues](https://img.shields.io/github/issues/ng2-ui/auto-complete.svg)](https://github.com/ng2-ui/auto-complete/issues)
+[![CI](https://img.shields.io/github/actions/workflow/status/ng2-ui/auto-complete/ci.yml?branch=master&style=flat-square&logo=githubactions&logoColor=white&label=CI)](https://github.com/ng2-ui/auto-complete/actions/workflows/ci.yml)
+[![npm version](https://img.shields.io/npm/v/@ngui/auto-complete?style=flat-square&logo=npm&color=cb3837)](https://www.npmjs.com/package/@ngui/auto-complete)
+[![npm downloads](https://img.shields.io/npm/dm/@ngui/auto-complete?style=flat-square&color=cb3837)](https://www.npmjs.com/package/@ngui/auto-complete)
+[![Angular](https://img.shields.io/badge/Angular-22-DD0031?style=flat-square&logo=angular&logoColor=white)](https://angular.dev)
+[![types](https://img.shields.io/npm/types/@ngui/auto-complete?style=flat-square)](https://www.npmjs.com/package/@ngui/auto-complete)
+[![license](https://img.shields.io/npm/l/@ngui/auto-complete?style=flat-square&color=blue)](LICENSE.md)
 
 A versatile Angular autocomplete library that works as both a **directive** (attached to any input) and a **standalone component**.
 


### PR DESCRIPTION
## What & why

Modernize the README status-badge row for consistency and signal.

**Before:** `CI · npm version · npm downloads (total) · npm license · GitHub issues` — mixed badge styles (GitHub's native `badge.svg` vs shields), no logos, lifetime download count, and an open-issues count that isn't a quality signal for consumers.

**After:** `CI · npm version · npm downloads (monthly) · Angular 22 · types · license`

Changes:

- **CI** routed through shields.io (`github/actions/workflow/status`) so it shares one `flat-square` style and gains a logo.
- **Downloads** `npm/dt` → `npm/dm` (monthly) — a truer liveness signal than a lifetime count dominated by old versions.
- **Added** an Angular-version badge (tracks the library major) and an `npm/types` badge advertising bundled TypeScript types.
- **License** badge now links to `LICENSE.md`.
- **Dropped** the GitHub-issues count.

Consistent `flat-square` style with brand logos throughout.

### Notes

- The Angular badge is **static** (a `^22.0.0` peer range doesn't render cleanly as a dynamic badge). Added a reminder in `CLAUDE.md` to bump it on each Angular major.
- A bundle-size (bundlephobia min+gzip) badge was considered but left out — the bundlephobia API is returning 500s right now.

Docs-only (README + CLAUDE.md, both markdown) — no library/app source touched, so **no release and no CHANGELOG entry**.

Generated with [Claude Code](https://claude.com/claude-code)
