### PR TITLE
chore: sync package-lock with postinstall script flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "auto-complete",
       "version": "0.0.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@angular/cdk": "^22.0.2",


### PR DESCRIPTION
## What & why

Follow-up to #519. That PR added a `postinstall` hook, which makes the root package an install-script package — so npm now records `"hasInstallScript": true` in `package-lock.json`. The lockfile wasn't regenerated in #519, so every `npm install` re-adds that one line and dirties the working tree.

This commits the one-line lockfile sync so the tree stays clean.

## Validation

Lockfile metadata only — no dependency changes, no library/app source touched, so **no release and no CHANGELOG entry**. `npm install` leaves the tree clean after this.

Generated with [Claude Code](https://claude.com/claude-code)
